### PR TITLE
Drop existing view before attempting to create

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -10,7 +10,7 @@ module Scenic
       end
 
       def self.create_view(name, sql_definition)
-        execute "CREATE VIEW #{name} AS #{sql_definition};"
+        execute "CREATE OR REPLACE VIEW #{name} AS #{sql_definition};"
       end
 
       def self.drop_view(name)

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -9,6 +9,19 @@ module Scenic
 
           expect(Postgres.views.map(&:name)).to include("greetings")
         end
+
+        it "replaces a view with a new view if a view with that name already "\
+          "exists" do
+          Postgres.create_view("greetings", "SELECT text 'hi' AS greeting")
+          Postgres.create_view("greetings", "SELECT text 'bye' AS greeting")
+
+          expect(Postgres.views).to eq([
+            View.new(
+              "viewname" => "greetings",
+              "definition" => "SELECT 'bye'::text AS greeting;",
+            ),
+          ])
+        end
       end
 
       describe "drop_view" do


### PR DESCRIPTION
Reloading a schema from scratch (on development or test) is causing an error
when ActiveRecord attempts to recreate views that are already present in the
database (in my case, it was `pg_stat_statements`). This change uses `DROP
VIEW`'s `IF EXISTS` argument to silently drop the view before attempting to
create it.

Fixes #55.