### PR TITLE
Don't dump PG system views

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -17,6 +17,10 @@ module Scenic
         execute "DROP VIEW #{name};"
       end
 
+      def self.extensions(base = ActiveRecord::Base)
+        base.connection.extensions
+      end
+
       private
 
       def self.execute(sql, base = ActiveRecord::Base)

--- a/lib/scenic/railtie.rb
+++ b/lib/scenic/railtie.rb
@@ -5,6 +5,8 @@ module Scenic
     initializer "scenic.load" do
       ActiveSupport.on_load :active_record do
         Scenic.load
+
+        ActiveRecord::SchemaDumper.ignore_tables += Scenic.database.extensions
       end
     end
   end

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -20,4 +20,15 @@ describe Scenic::SchemaDumper, :db do
 
     expect(Search.first.haystack).to eq "needle"
   end
+
+  it "does not dump views belonging to Posgresql extensions" do
+    Search.connection.enable_extension("pg_stat_statements")
+    Search.connection.reconnect!
+    stream = StringIO.new
+
+    ActiveRecord::SchemaDumper.dump(Search.connection, stream)
+
+    output = stream.string
+    expect(output).not_to include "create_view :pg_stat_statements"
+  end
 end


### PR DESCRIPTION
Postgres' convention for system views is to start the view name with a
`pg_` prefix. Adding these view names to the list of ignored views when we
dump the schema to prevent conflicts with PG and extensions' views of database
metadata.

This change is meant to resolve #55.