### PR TITLE
Update Travis Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@ before_install:
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'
 before_script:
-  - pushd spec/dummy && bundle exec rake db:create && popd
+  - pushd spec/dummy && bundle exec rake db:create && mkdir db/views && popd
 branches:
   only:
     - master
-cache:
-  - bundler
 language:
   - ruby
 notifications:
   email:
     - false
 rvm:
-  - 2.1.1
+  - 2.1.5
+  - 2.2.0
+sudo: false

--- a/spec/support/view_definition_helpers.rb
+++ b/spec/support/view_definition_helpers.rb
@@ -4,6 +4,6 @@ module ViewDefinitionHelpers
     File.open(definition.full_path, "w") { |f| f.write(schema) }
     yield
   ensure
-    File.delete definition.full_path
+    FileUtils.rm_f(definition.full_path)
   end
 end


### PR DESCRIPTION
* Use the latest version of Ruby 2.1
* Add Ruby 2.2.0 to the testing matrix
* Enable the Travis container infrastructure (sudo: false)
* Disable bundler cache. We want Travis to resolve and install
 dependencies each time, as we want to know about issues that pop up
 with newer dependency versions.