### PR TITLE
DROP VIEW IF EXISTS view_name

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -13,8 +13,11 @@ module Scenic
         execute "CREATE VIEW #{name} AS #{sql_definition};"
       end
 
-      def self.drop_view(name)
-        execute "DROP VIEW #{name};"
+      def self.drop_view(name, if_exists = false)
+        sql = "DROP VIEW"
+        sql += " IF EXISTS" if if_exists
+        sql += " #{name};"
+        execute sql
       end
 
       private

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -48,8 +48,8 @@ module Scenic
     #   drop_view(:users_who_recently_logged_in, 3)
     #
     # Returns the database response from executing the DROP VIEW statement.
-    def drop_view(name, revert_to_version: nil)
-      Scenic.database.drop_view(name)
+    def drop_view(name, revert_to_version: nil, if_exists: false)
+      Scenic.database.drop_view(name, if_exists)
     end
 
     # Public: Update a database view to a new version by first dropping the

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -41,7 +41,7 @@ module Scenic
       it "removes a view from the database" do
         connection.drop_view :name
 
-        expect(Scenic.database).to have_received(:drop_view).with(:name)
+        expect(Scenic.database).to have_received(:drop_view).with(:name, false)
       end
     end
 
@@ -54,7 +54,7 @@ module Scenic
 
         connection.update_view(:name, version: 3)
 
-        expect(Scenic.database).to have_received(:drop_view).with(:name)
+        expect(Scenic.database).to have_received(:drop_view).with(:name, false)
         expect(Scenic.database).to have_received(:create_view)
           .with(:name, definition.to_sql)
       end


### PR DESCRIPTION
 this is useful if your migrating from another solution