### PR TITLE
Add blank line between view definitions on db/schema.rb

### DIFF
--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -18,6 +18,7 @@ module Scenic
         create_view :#{name}, sql_definition:<<-\SQL
           #{definition}
         SQL
+        
       DEFINITION
     end
   end


### PR DESCRIPTION
Before:

```ruby
# db/schema.rb
create_view :view_users, sql_definition:<<-SQL
Select * From users;
SQL
create_view :view_posts, sql_definition:<<-SQL
Select * From posts;
SQL
```

Now:
```ruby
# db/schema.rb
create_view :view_users, sql_definition:<<-SQL
Select * From users;
SQL

create_view :view_posts, sql_definition:<<-SQL
Select * From posts;
SQL
```