### PR TITLE
Support Ruby 2.0.0

### DIFF
--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -9,9 +9,9 @@ require "scenic/view"
 
 module Scenic
   def self.load
-    ActiveRecord::ConnectionAdapters::AbstractAdapter.include Scenic::Statements
-    ActiveRecord::Migration::CommandRecorder.include Scenic::CommandRecorder
-    ActiveRecord::SchemaDumper.include Scenic::SchemaDumper
+    ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:include, Scenic::Statements)
+    ActiveRecord::Migration::CommandRecorder.send(:include, Scenic::CommandRecorder)
+    ActiveRecord::SchemaDumper.send(:include, Scenic::SchemaDumper)
   end
 
   def self.database


### PR DESCRIPTION
While Loading the rails console we're getting this error
```scenic.rb:12:in `load': private method `include' called for ActiveRecord::ConnectionAdapters::AbstractAdapter:Class (NoMethodError)````

We fixed the calling the method ìnclude`with send, what do you think guys?