### PR TITLE
Improve formatting of dumped view

### DIFF
--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -14,11 +14,11 @@ module Scenic
     end
 
     def to_schema
-      <<-DEFINITION.strip_heredoc
-        create_view :#{name}, sql_definition:<<-\SQL
-          #{definition}
-        SQL
+      <<-DEFINITION
 
+  create_view :#{name}, sql_definition: <<-\SQL
+    #{definition.indent(2)}
+  SQL
       DEFINITION
     end
   end


### PR DESCRIPTION
* Blank line should go above the view to separate it from content above
  and still guarantee a blank line between views
* `stip_heredoc` wasn't working as expected. Postgres does a reasonable
  job of formatting the query, we just want to be sure it is readable in
  the schema. `indent` helps with that.

*Before:*
![janky](https://cloud.githubusercontent.com/assets/152152/10255791/bb90bcfa-691a-11e5-8e5b-f92ceb6a3a12.png)

*After:*
![better](https://cloud.githubusercontent.com/assets/152152/10255766/8aaaead4-691a-11e5-816c-c9f14697a036.png)
