### PR TITLE
Fix failing tests with RSpec 3.3

### DIFF
--- a/scenic.gemspec
+++ b/scenic.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.5'
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec', '>= 3.3'
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'ammeter'
+  spec.add_development_dependency 'ammeter', '>= 1.1.3'
 
   spec.add_dependency 'activerecord', '>= 4.0.0'
   spec.add_dependency 'railties', '>= 4.0.0'

--- a/spec/support/generator_spec_setup.rb
+++ b/spec/support/generator_spec_setup.rb
@@ -1,3 +1,4 @@
+require "rspec/rails"
 require "ammeter/rspec/generator/example.rb"
 require "ammeter/rspec/generator/matchers.rb"
 require "ammeter/init"


### PR DESCRIPTION
There is no released version of ammeter that works with the latest
version of RSpec for libraries not using fixtures. I've asked for a
release of ammeter, but in the meantime, we need to pull latest from
git. See: https://github.com/alexrothenberg/ammeter/pull/50