### PR TITLE
Document and automate test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'
-before_script:
-  - pushd spec/dummy && bundle exec rake db:create && mkdir db/views && popd
 branches:
   only:
     - master
+install:
+  - travis_retry bin/setup
 language:
   - ruby
 notifications:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+We love pull requests from everyone.  By participating in this project, you
+agree to abide by the thoughtbot [code of conduct].
+
+[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
+
+We expect everyone to follow the code of conduct anywhere in thoughtbot's
+project codebases, issue trackers, chatrooms, and mailing lists.
+
+## Setting Up for Development
+
+1. For the repository.
+2. Run `bin/setup`, which will install dependencies and create the dummy
+   application database.
+3. Run `rake` to verify that the tests pass.
+4. Make your change with new passing tests, following the [style guide].
+5. Write a [good commit message], push your fork, and submit a pull request.
+
+[style guide]: https://github.com/thoughtbot/guides/tree/master/style
+[good commit message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+
+Others will give constructive feedback.  This is a time for discussion and
+improvements, and making the necessary changes will be required before we can
+merge the contribution.

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,9 @@ task :smoke do
   exec "spec/smoke"
 end
 
+namespace :dummy do
+  require_relative "spec/dummy/config/application"
+  Dummy::Application.load_tasks
+end
+
 task default: [:spec, :smoke]

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+gem install bundler --conservative
+bundle check || bundle install
+bundle exec rake dummy:db:create


### PR DESCRIPTION
Scenic tests don't immediately work by cloning the repo, running `bundle
install` and `rake`. We also need to be sure the dummy application
database is created.

`bin/setup` will now do this for you. This is documented in the new
CONTRIBUTING guide.

This closes #67.