### PR TITLE
Delegate to rails model generator

### DIFF
--- a/lib/generators/scenic/model/model_generator.rb
+++ b/lib/generators/scenic/model/model_generator.rb
@@ -1,19 +1,16 @@
 require "rails/generators"
+require "rails/generators/rails/model/model_generator"
 require "generators/scenic/view/view_generator"
 
 module Scenic
   module Generators
     class ModelGenerator < Rails::Generators::NamedBase
-      source_root File.expand_path("../templates", __FILE__)
-
-      check_class_collision
-
-      def create_model_file
-        template("model.erb", "app/models/#{file_name}.rb")
+      def invoke_rails_model_generator
+        invoke "model", [name], options.merge(migration: false)
       end
 
       def invoke_view_generator
-        invoke "scenic:view", [singular_name]
+        invoke "scenic:view", [table_name], options
       end
     end
   end

--- a/lib/generators/scenic/model/templates/model.erb
+++ b/lib/generators/scenic/model/templates/model.erb
@@ -1,2 +1,0 @@
-class <%= class_name %> < ActiveRecord::Base
-end


### PR DESCRIPTION
The rails model generator supports lots of things our simplistic
`scenic:model` generator does not. Specifically, the rails model
generator can handle namespaced models by generating the right class
name and a module that sets the table name prefix properly for the
entire namespace.