### PR TITLE
Allow configuration of database adapter

### DIFF
--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -1,3 +1,4 @@
+require "scenic/configuration"
 require "scenic/adapters/postgres"
 require "scenic/command_recorder"
 require "scenic/definition"
@@ -14,7 +15,10 @@ module Scenic
     ActiveRecord::SchemaDumper.include Scenic::SchemaDumper
   end
 
+  # The current database adapter used by Scenic.
+  # This defaults to [Adapters::Postgres] but can be overridden
+  # via [Configuration].
   def self.database
-    Scenic::Adapters::Postgres
+    configuration.database
   end
 end

--- a/lib/scenic/configuration.rb
+++ b/lib/scenic/configuration.rb
@@ -1,0 +1,34 @@
+module Scenic
+  class Configuration
+    # The Scenic database adapter class to use when executing SQL.
+    # Defualts to [Scenic::Adapters::Postgres]
+    # @return Scenic adapter
+    attr_accessor :database
+
+    def initialize
+      @database = Scenic::Adapters::Postgres
+    end
+  end
+
+  # @return [Scenic::Configuration] Scenic's current configuration
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  # Set Scenic's configuration
+  # @param config [Scenic::Configuration]
+  def self.configuration=(config)
+    @configuration = config
+  end
+
+  # Modify Scenic's current configuration
+  # @yieldparam [Scenic::Configuration] config current Scenic config
+  # ```
+  # Scenic.configure do |config|
+  #   config.database = Scenic::Adapters::Postgres
+  # end
+  # ```
+  def self.configure
+    yield configuration
+  end
+end

--- a/spec/scenic/configuration_spec.rb
+++ b/spec/scenic/configuration_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+module Scenic
+  describe Configuration do
+    after { restore_default_config }
+
+    it "defaults the database adapter to postgres" do
+      expect(Scenic.configuration.database).to eq Adapters::Postgres
+      expect(Scenic.database).to eq Adapters::Postgres
+    end
+
+    it "allows the database adapter to be set" do
+      adapter = double("Scenic Adapter")
+
+      Scenic.configure do |config|
+        config.database = adapter
+      end
+
+      expect(Scenic.configuration.database).to eq adapter
+      expect(Scenic.database).to eq adapter
+    end
+
+    def restore_default_config
+      Scenic.configuration = Configuration.new
+    end
+  end
+end


### PR DESCRIPTION
At this point, we don't have any plans to offer different in-tree
database adapters, but this minimal configuration should allow other
developers to write them and plug them in without monkey-patching
Scenic.