### PR TITLE
Remove use of alias_method_chain

### DIFF
--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -12,7 +12,7 @@ module Scenic
   def self.load
     ActiveRecord::ConnectionAdapters::AbstractAdapter.include Scenic::Statements
     ActiveRecord::Migration::CommandRecorder.include Scenic::CommandRecorder
-    ActiveRecord::SchemaDumper.include Scenic::SchemaDumper
+    ActiveRecord::SchemaDumper.prepend Scenic::SchemaDumper
   end
 
   # The current database adapter used by Scenic.

--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -2,12 +2,8 @@ require "rails"
 
 module Scenic
   module SchemaDumper
-    extend ActiveSupport::Concern
-
-    included { alias_method_chain :tables, :views }
-
-    def tables_with_views(stream)
-      tables_without_views(stream)
+    def tables(stream)
+      super
       views(stream)
     end
 


### PR DESCRIPTION
Rails 5 deprecates `alias_method_chain` in favor of `Module.prepend`
which is provided in Ruby 2.