### PR TITLE
Extract an abstract database adapter

### DIFF
--- a/lib/scenic/adapters/abstract.rb
+++ b/lib/scenic/adapters/abstract.rb
@@ -1,0 +1,82 @@
+module Scenic
+  module Adapters
+    # Abstract base class for Scenic database adapters.
+    class Abstract
+      # Returns an array of views in the datbase as [Scenic::View] objects.
+      #
+      # This collection of views is used by the [Scenic::SchemaDumper] to
+      # populate the `schema.rb` file.
+      #
+      # This method has no default implementation and must be implemented by
+      # all adapters.
+      #
+      # @return [Array<Scenic::View>]
+      def views
+        raise NotImplementedError
+      end
+
+      # Creates a view in the database.
+      #
+      # This method has a default implementation that should work for all
+      # relational databases that support views.
+      #
+      # @param name The name of the view to create
+      # @param sql_definition the SQL schema for the view.
+      # @return [void]
+      def create_view(name, sql_definition)
+        execute "CREATE VIEW #{name} AS #{sql_definition};"
+      end
+
+      # Drops the named view from the database
+      #
+      # This method has a default implementation that should work for all
+      # relational databases that support views.
+      #
+      # @param name The name of the view to drop
+      # @return [void]
+      def drop_view(name)
+        execute "DROP VIEW #{name};"
+      end
+
+      # Creates a materialized view in the database
+      #
+      # This method has no default implementation and should be implemented by
+      # adapters that support materialized views.
+      #
+      # @param name The name of the materialized view to create
+      # @param sql_definition The SQL schema that defines the materialized view.
+      # @return [void]
+      def create_materialized_view(name, sql_definition)
+        raise NotImplementedError
+      end
+
+      # Drops a materialized view in the database
+      #
+      # This method has no default implementation and should be implemented by
+      # adapters that support materialized views.
+      #
+      # @param name The name of the materialized view to drop.
+      # @return [void]
+      def drop_materialized_view(name)
+        raise NotImplementedError
+      end
+
+      # Refreshes a materialized view from its SQL schema.
+      #
+      # This method has no default implementation and should be implemented by
+      # adapters that support materialized views.
+      #
+      # @param name The name of the materialized view to refresh..
+      # @return [void]
+      def refresh_materialized_view(name)
+        raise NotImplementedError
+      end
+
+      private
+
+      def execute(sql, base = ActiveRecord::Base)
+        base.connection.execute sql
+      end
+    end
+  end
+end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -1,7 +1,15 @@
+require "scenic/adapters/abstract"
+
 module Scenic
   module Adapters
-    module Postgres
-      def self.views
+    class Postgres < Abstract
+      # Returns an array of views in the database.
+      #
+      # This collection of views is used by the [Scenic::SchemaDumper] to
+      # populate the `schema.rb` file.
+      #
+      # @return [Array<Scenic::View>]
+      def views
         execute(<<-SQL).map { |result| Scenic::View.new(result) }
           SELECT viewname, definition, FALSE AS materialized
           FROM pg_views
@@ -15,30 +23,29 @@ module Scenic
         SQL
       end
 
-      def self.create_view(name, sql_definition)
-        execute "CREATE VIEW #{name} AS #{sql_definition};"
-      end
-
-      def self.create_materialized_view(name, sql_definition)
+      # Creates a materialized view in the database
+      #
+      # @param name The name of the materialized view to create
+      # @param sql_definition The SQL schema that defines the materialized view.
+      # @return [void]
+      def create_materialized_view(name, sql_definition)
         execute "CREATE MATERIALIZED VIEW #{name} AS #{sql_definition};"
       end
 
-      def self.drop_view(name)
-        execute "DROP VIEW #{name};"
-      end
-
-      def self.drop_materialized_view(name)
+      # Drops a materialized view in the database
+      #
+      # @param name The name of the materialized view to drop.
+      # @return [void]
+      def drop_materialized_view(name)
         execute "DROP MATERIALIZED VIEW #{name};"
       end
 
-      def self.refresh_materialized_view(name)
+      # Refreshes a materialized view from its SQL schema.
+      #
+      # @param name The name of the materialized view to refresh..
+      # @return [void]
+      def refresh_materialized_view(name)
         execute "REFRESH MATERIALIZED VIEW #{name};"
-      end
-
-      private
-
-      def self.execute(sql, base = ActiveRecord::Base)
-        base.connection.execute sql
       end
     end
   end

--- a/lib/scenic/configuration.rb
+++ b/lib/scenic/configuration.rb
@@ -1,12 +1,12 @@
 module Scenic
   class Configuration
-    # The Scenic database adapter class to use when executing SQL.
-    # Defualts to [Scenic::Adapters::Postgres]
+    # The Scenic database adapter instance to use when executing SQL.
+    # Defualts to [Scenic::Adapters::Postgres.new]
     # @return Scenic adapter
     attr_accessor :database
 
     def initialize
-      @database = Scenic::Adapters::Postgres
+      @database = Scenic::Adapters::Postgres.new
     end
   end
 

--- a/spec/scenic/configuration_spec.rb
+++ b/spec/scenic/configuration_spec.rb
@@ -5,8 +5,8 @@ module Scenic
     after { restore_default_config }
 
     it "defaults the database adapter to postgres" do
-      expect(Scenic.configuration.database).to eq Adapters::Postgres
-      expect(Scenic.database).to eq Adapters::Postgres
+      expect(Scenic.configuration.database).to be_a Adapters::Postgres
+      expect(Scenic.database).to be_a Adapters::Postgres
     end
 
     it "allows the database adapter to be set" do

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 module Scenic
   describe Scenic::Statements do
     before do
-      allow(Scenic).to receive(:database)
-        .and_return(class_double("Scenic::Adapters::Postgres").as_null_object)
+      adapter = instance_double("Scenic::Adapaters::Postgres").as_null_object
+      allow(Scenic).to receive(:database).and_return(adapter)
     end
 
     describe "create_view" do


### PR DESCRIPTION
`Scenic::Adapters::Abstract` lays out the interface for Scenic database
adapters. It contains template methods for all methods required of a
Scenic adapter with actual implementations for `create_view` and
`drop_view` which are identical for basic use cases across all
relational databases I've encountered.

Using the abstract adapter as a base, for instance, a hypothetical MySQL
adapter would need only to implement the `views` method that retrieves
all views and their associated schema for dumping to the `schema.rb`
file.

As part of this extraction, I converted to using instances for the
adapters rather than class methods. This feels better and wasn't a good
deal of work. I'd prefer instance based APIs rather than class-based
APIs.

Documentation was added for all adapter methods.