### PR TITLE
Use object instance for adapter interface

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -1,7 +1,13 @@
 module Scenic
   module Adapters
-    module Postgres
-      def self.views
+    class Postgres
+      # Returns an array of views in the database.
+      #
+      # This collection of views is used by the [Scenic::SchemaDumper] to
+      # populate the `schema.rb` file.
+      #
+      # @return [Array<Scenic::View>]
+      def views
         execute(<<-SQL).map { |result| Scenic::View.new(result) }
           SELECT viewname, definition, FALSE AS materialized
           FROM pg_views
@@ -15,29 +21,51 @@ module Scenic
         SQL
       end
 
-      def self.create_view(name, sql_definition)
+      # Creates a view in the database.
+      #
+      # @param name The name of the view to create
+      # @param sql_definition the SQL schema for the view.
+      # @return [void]
+      def create_view(name, sql_definition)
         execute "CREATE VIEW #{name} AS #{sql_definition};"
       end
 
-      def self.create_materialized_view(name, sql_definition)
-        execute "CREATE MATERIALIZED VIEW #{name} AS #{sql_definition};"
-      end
-
-      def self.drop_view(name)
+      # Drops the named view from the database
+      #
+      # @param name The name of the view to drop
+      # @return [void]
+      def drop_view(name)
         execute "DROP VIEW #{name};"
       end
 
-      def self.drop_materialized_view(name)
+      # Creates a materialized view in the database
+      #
+      # @param name The name of the materialized view to create
+      # @param sql_definition The SQL schema that defines the materialized view.
+      # @return [void]
+      def create_materialized_view(name, sql_definition)
+        execute "CREATE MATERIALIZED VIEW #{name} AS #{sql_definition};"
+      end
+
+      # Drops a materialized view in the database
+      #
+      # @param name The name of the materialized view to drop.
+      # @return [void]
+      def drop_materialized_view(name)
         execute "DROP MATERIALIZED VIEW #{name};"
       end
 
-      def self.refresh_materialized_view(name)
+      # Refreshes a materialized view from its SQL schema.
+      #
+      # @param name The name of the materialized view to refresh..
+      # @return [void]
+      def refresh_materialized_view(name)
         execute "REFRESH MATERIALIZED VIEW #{name};"
       end
 
       private
 
-      def self.execute(sql, base = ActiveRecord::Base)
+      def execute(sql, base = ActiveRecord::Base)
         base.connection.execute sql
       end
     end

--- a/lib/scenic/configuration.rb
+++ b/lib/scenic/configuration.rb
@@ -1,12 +1,12 @@
 module Scenic
   class Configuration
-    # The Scenic database adapter class to use when executing SQL.
-    # Defualts to [Scenic::Adapters::Postgres]
+    # The Scenic database adapter instance to use when executing SQL.
+    # Defualts to an instance of [Scenic::Adapters::Postgres]
     # @return Scenic adapter
     attr_accessor :database
 
     def initialize
-      @database = Scenic::Adapters::Postgres
+      @database = Scenic::Adapters::Postgres.new
     end
   end
 

--- a/spec/scenic/configuration_spec.rb
+++ b/spec/scenic/configuration_spec.rb
@@ -5,8 +5,8 @@ module Scenic
     after { restore_default_config }
 
     it "defaults the database adapter to postgres" do
-      expect(Scenic.configuration.database).to eq Adapters::Postgres
-      expect(Scenic.database).to eq Adapters::Postgres
+      expect(Scenic.configuration.database).to be_a Adapters::Postgres
+      expect(Scenic.database).to be_a Adapters::Postgres
     end
 
     it "allows the database adapter to be set" do

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 module Scenic
   describe Scenic::Statements do
     before do
-      allow(Scenic).to receive(:database)
-        .and_return(class_double("Scenic::Adapters::Postgres").as_null_object)
+      adapter = instance_double("Scenic::Adapaters::Postgres").as_null_object
+      allow(Scenic).to receive(:database).and_return(adapter)
     end
 
     describe "create_view" do


### PR DESCRIPTION
There's no great reason to use a class-based interface when we can just
as easily pass an interface.

Also added documentation for the adapter methods.