### PR TITLE
Isolate Postgres view representation

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -8,7 +8,7 @@ module Scenic
       #
       # @return [Array<Scenic::View>]
       def views
-        execute(<<-SQL).map { |result| Scenic::View.new(result) }
+        execute(<<-SQL).map { |result| view_from_database(result) }
           SELECT viewname, definition, FALSE AS materialized
           FROM pg_views
           WHERE schemaname = ANY (current_schemas(false))
@@ -67,6 +67,14 @@ module Scenic
 
       def execute(sql, base = ActiveRecord::Base)
         base.connection.execute sql
+      end
+
+      def view_from_database(result)
+        Scenic::View.new(
+          name: result["viewname"],
+          definition: result["definition"].strip,
+          materialized: result["materialized"] == "t",
+        )
       end
     end
   end

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -3,10 +3,10 @@ module Scenic
     attr_reader :name, :definition, :materialized
     delegate :<=>, to: :name
 
-    def initialize(view_row)
-      @name = view_row["viewname"]
-      @definition = view_row["definition"].strip
-      @materialized = view_row["materialized"] == "t"
+    def initialize(name:, definition:, materialized:)
+      @name = name
+      @definition = definition
+      @materialized = materialized
     end
 
     def ==(other)

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -65,14 +65,14 @@ module Scenic
 
         expect(adapter.views).to eq([
           Scenic::View.new(
-            "viewname" => "farewells",
-            "definition" => " SELECT 'bye'::text AS farewell;",
-            "materialized" => "t",
+            name: "farewells",
+            definition: "SELECT 'bye'::text AS farewell;",
+            materialized: true,
           ),
           Scenic::View.new(
-            "viewname" => "greetings",
-            "definition" => " SELECT 'hi'::text AS greeting;",
-            "materialized" => "f",
+            name: "greetings",
+            definition: "SELECT 'hi'::text AS greeting;",
+            materialized: false,
           ),
         ])
       end


### PR DESCRIPTION
Previously, we constructed a `View` object by passing the Postgres
database result directly to the `View` constructor. This leaks
Postgres-specific information.

This change updates the postgres adapter so it constructs the `View`
object by parsing the database result itself. This will make `View` more
easily used by additional adapters.