### PR TITLE
Document public API

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,5 @@
+--hide-api private
+--hide-api extension
+--exclude templates
+--markup markdown
+--markup-provider redcarpet

--- a/lib/generators/scenic/generators.rb
+++ b/lib/generators/scenic/generators.rb
@@ -1,0 +1,11 @@
+module Scenic
+  # Scenic provides generators for creating and updating views and ActiveRecord
+  # models that are backed by views.
+  #
+  # See:
+  # * {file:lib/generators/scenic/model/USAGE Model Generator}
+  # * {file:lib/generators/scenic/view/USAGE View Generator}
+  # * {file:README.md README}
+  module Generators
+  end
+end

--- a/lib/generators/scenic/materializable.rb
+++ b/lib/generators/scenic/materializable.rb
@@ -1,5 +1,6 @@
 module Scenic
   module Generators
+    # @api private
     module Materializable
       extend ActiveSupport::Concern
 

--- a/lib/generators/scenic/model/model_generator.rb
+++ b/lib/generators/scenic/model/model_generator.rb
@@ -5,6 +5,7 @@ require "generators/scenic/materializable"
 
 module Scenic
   module Generators
+    # @api private
     class ModelGenerator < Rails::Generators::NamedBase
       include Scenic::Generators::Materializable
       source_root File.expand_path("../templates", __FILE__)

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -4,6 +4,7 @@ require "generators/scenic/materializable"
 
 module Scenic
   module Generators
+    # @api private
     class ViewGenerator < Rails::Generators::NamedBase
       include Rails::Generators::Migration
       include Scenic::Generators::Materializable

--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -8,7 +8,13 @@ require "scenic/statements"
 require "scenic/version"
 require "scenic/view"
 
+# Scenic adds methods `ActiveRecord::Migration` to create and manage database
+# views in Rails applications.
 module Scenic
+  # Hooks Scenic into Rails.
+  #
+  # Enables scenic migration methods, migration reversability, and `schema.rb`
+  # dumping.
   def self.load
     ActiveRecord::ConnectionAdapters::AbstractAdapter.include Scenic::Statements
     ActiveRecord::Migration::CommandRecorder.include Scenic::CommandRecorder
@@ -16,8 +22,9 @@ module Scenic
   end
 
   # The current database adapter used by Scenic.
-  # This defaults to [Adapters::Postgres] but can be overridden
-  # via [Configuration].
+  #
+  # This defaults to {Adapters::Postgres} but can be overridden
+  # via {Configuration}.
   def self.database
     configuration.database
   end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -1,5 +1,19 @@
 module Scenic
+  # Scenic database adapters.
+  #
+  # Scenic ships with a Postgres adapter only but can be extended with
+  # additional adapters. The {Adapters::Postgres} adapter provides the
+  # interface.
   module Adapters
+    # An adapter for managing Postgres views.
+    #
+    # **This object is used internally by adapters and the schema dumper and is
+    # not intended to be used by application code. It is documented here for
+    # use by adapter gems.**
+    #
+    # For methods usable in migrations see {Statements}.
+    #
+    # @api extension
     class Postgres
       # Returns an array of views in the database.
       #

--- a/lib/scenic/command_recorder.rb
+++ b/lib/scenic/command_recorder.rb
@@ -1,6 +1,7 @@
 require "scenic/command_recorder/statement_arguments"
 
 module Scenic
+  # @api private
   module CommandRecorder
     def create_view(*args)
       record(:create_view, args)

--- a/lib/scenic/command_recorder/statement_arguments.rb
+++ b/lib/scenic/command_recorder/statement_arguments.rb
@@ -1,5 +1,6 @@
 module Scenic
   module CommandRecorder
+    # @api private
     class StatementArguments
       def initialize(args)
         @args = args.freeze

--- a/lib/scenic/configuration.rb
+++ b/lib/scenic/configuration.rb
@@ -1,6 +1,7 @@
 module Scenic
   class Configuration
     # The Scenic database adapter instance to use when executing SQL.
+    #
     # Defualts to an instance of [Scenic::Adapters::Postgres]
     # @return Scenic adapter
     attr_accessor :database
@@ -16,12 +17,14 @@ module Scenic
   end
 
   # Set Scenic's configuration
+  #
   # @param config [Scenic::Configuration]
   def self.configuration=(config)
     @configuration = config
   end
 
   # Modify Scenic's current configuration
+  #
   # @yieldparam [Scenic::Configuration] config current Scenic config
   # ```
   # Scenic.configure do |config|

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -1,4 +1,5 @@
 module Scenic
+  # @api private
   class Definition
     def initialize(name, version)
       @name = name

--- a/lib/scenic/railtie.rb
+++ b/lib/scenic/railtie.rb
@@ -1,6 +1,10 @@
 require "rails/railtie"
 
 module Scenic
+  # Automatically initializes Scenic in the context of a Rails application when
+  # ActiveRecord is loaded.
+  #
+  # @see Scenic.load
   class Railtie < Rails::Railtie
     initializer "scenic.load" do
       ActiveSupport.on_load :active_record do

--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -1,6 +1,7 @@
 require "rails"
 
 module Scenic
+  # @api private
   module SchemaDumper
     def tables(stream)
       super

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -1,20 +1,49 @@
 module Scenic
+  # The in-memory representation of a view definition.
+  #
+  # **This object is used internally by adapters and the schema dumper and is
+  # not intended to be used by application code. It is documented here for
+  # use by adapter gems.**
+  #
+  # @api extension
   class View
-    attr_reader :name, :definition, :materialized
+    # The name of the view
+    # @return [String]
+    attr_reader :name
+
+    # The SQL schema for the query that defines the view
+    # @return [String]
+    #
+    # @example
+    #   "SELECT name, email FROM users UNION SELECT name, email FROM contacts"
+    attr_reader :definition
+
+    # True if the view is materialized
+    # @return [Boolean]
+    attr_reader :materialized
+
+    # @api private
     delegate :<=>, to: :name
 
+    # Returns a new instance of View.
+    #
+    # @param name [String] The name of the view.
+    # @param definition [String] The SQL for the query that defines the view.
+    # @param materialized [String] `true` if the view is materialized.
     def initialize(name:, definition:, materialized:)
       @name = name
       @definition = definition
       @materialized = materialized
     end
 
+    # @api private
     def ==(other)
       name == other.name &&
         definition == other.definition &&
         materialized == other.materialized
     end
 
+    # @api private
     def to_schema
       materialized_option = materialized ? "materialized: true, " : ""
       <<-DEFINITION


### PR DESCRIPTION
* Added documentation where it was missing.
* Updated documentation to use yard formatting throughout.
* Marked internals as private (`SchemaDumper`, `CommandRecorder`, etc)

I did opt to document `Adapters::Postgres` and `View`. They are not
objects we expect end users to interact with, but the documentation will
be useful for anyone who wants to create an adapter.

Those objects are tagged with `@api extension` so we could filter them
from the default documentation with and update to the `.yardopts` file
if needed.