### PR TITLE
Remove errant instance variable reference

### DIFF
--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -8,7 +8,7 @@ module Scenic
     def to_sql
       File.read(full_path).tap do |content|
         if content.empty?
-          raise "Define view query in #{@path} before migrating."
+          raise "Define view query in #{path} before migrating."
         end
       end
     end


### PR DESCRIPTION
This commit removes an errant instance variable reference in favor of a method call in the same name.