### PR TITLE
add `sql_definition` option to drop_view call

### DIFF
--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -51,7 +51,7 @@ module Scenic
     # @example Drop a view, rolling back to version 3 on rollback
     #   drop_view(:users_who_recently_logged_in, revert_to_version: 3)
     #
-    def drop_view(name, revert_to_version: nil, materialized: false)
+    def drop_view(name, revert_to_version: nil, materialized: false, sql_definition: nil)
       if materialized
         Scenic.database.drop_materialized_view(name)
       else


### PR DESCRIPTION
... so reverting create_view with sql_definition would not fail