### PR TITLE
Adding support to refresh materialized views concurrently

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ project codebases, issue trackers, chatrooms, and mailing lists.
 
 ## Setting Up for Development
 
-1. For the repository.
+1. Fork the repository.
 2. Run `bin/setup`, which will install dependencies and create the dummy
    application database.
 3. Run `rake` to verify that the tests pass.

--- a/README.md
+++ b/README.md
@@ -129,14 +129,23 @@ those? Of course!
 
 The `scenic:view` and `scenic:model` generators accept a `--materialized`
 option for this purpose. When used with the model generator, your model will
-have the following method defined as a convenience to aid in scheduling
+have the following methods defined as conveniences to aid in scheduling
 refreshes:
 
 ```ruby
 def self.refresh
   Scenic.database.refresh_materialized_view(table_name)
 end
+
+def self.refresh_concurrently
+  Scenic.database.refresh_materialized_view_concurrently(table_name)
+end
 ```
+
+As a reminder, any materialized view that you want to refresh concurrently must
+have a unique index. If you attempt to refresh a materialized view concurrently
+without a unique index, that will raise an `ActiveRecord::StatementInvalid`
+exception.
 
 ## I don't need this view anymore. Make it go away.
 

--- a/lib/generators/scenic/model/templates/model.erb
+++ b/lib/generators/scenic/model/templates/model.erb
@@ -1,3 +1,7 @@
   def self.refresh
     Scenic.database.refresh_materialized_view(table_name)
   end
+
+  def self.refresh_concurrently
+    Scenic.database.refresh_materialized_view_concurrently(table_name)
+  end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -77,6 +77,14 @@ module Scenic
         execute "REFRESH MATERIALIZED VIEW #{name};"
       end
 
+      # Refreshes a materialized view concurrently from its SQL schema.
+      #
+      # @param name The name of the materialized view to refresh..
+      # @return [void]
+      def refresh_materialized_view_concurrently(name)
+        execute "REFRESH MATERIALIZED VIEW CONCURRENTLY #{name};"
+      end
+
       private
 
       def execute(sql, base = ActiveRecord::Base)

--- a/spec/generators/scenic/model/model_generator_spec.rb
+++ b/spec/generators/scenic/model/model_generator_spec.rb
@@ -25,11 +25,12 @@ module Scenic::Generators
       expect(model_definition).to have_correct_syntax
     end
 
-    it "adds a refresh method to materialized models" do
+    it "adds refresh and refresh_concurrently methods to materialized models" do
       run_generator ["active_user", "--materialized"]
       model_definition = file("app/models/active_user.rb")
 
       expect(model_definition).to contain("self.refresh")
+      expect(model_definition).to contain("self.refresh_concurrently")
       expect(model_definition).to have_correct_syntax
     end
   end


### PR DESCRIPTION
This PR adds support for refreshing materialized views concurrently, addressing Issue #92. I've added the necessary code to the Postgres adapter, updated the model generator to include a new `refresh_concurrently` method, and added a test to ensure that the `refresh_concurrently` method is indeed being added to new models for materialized views.

Since the ability to refresh a materialized view concurrently is dependent on a unique index without a `where` clause on that view, it is possible that calling the method will raise an exception. I thought about rescuing that exception and logging a message for the user to let them know that a concurrent refresh wasn't possible, but I felt that in this case an exception should be raised so the user doesn't think the refresh succeeded if they're not looking at their logs or for some reason doesn't see the console output. I've updated the README so there is documentation that the exception will be raised in those cases, so hopefully users won't be surprised.

There was also a small typo in `CONTRIBUTING.md`, which I've fixed here as well. It was so small I didn't think it deserved its own PR.