### PR TITLE
Don't sort views pulled from Postgres

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -31,7 +31,6 @@ module Scenic
           SELECT matviewname AS viewname, definition, TRUE AS materialized
           FROM pg_matviews
           WHERE schemaname = ANY (current_schemas(false))
-          ORDER BY viewname
         SQL
       end
 

--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -15,7 +15,7 @@ module Scenic
     end
 
     def views_in_database
-      @views_in_database ||= Scenic.database.views.sort
+      @views_in_database ||= Scenic.database.views
     end
 
     private

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -22,9 +22,6 @@ module Scenic
     # @return [Boolean]
     attr_reader :materialized
 
-    # @api private
-    delegate :<=>, to: :name
-
     # Returns a new instance of View.
     #
     # @param name [String] The name of the view.

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -65,14 +65,14 @@ module Scenic
 
         expect(adapter.views).to eq([
           Scenic::View.new(
-            name: "farewells",
-            definition: "SELECT 'bye'::text AS farewell;",
-            materialized: true,
-          ),
-          Scenic::View.new(
             name: "greetings",
             definition: "SELECT 'hi'::text AS greeting;",
             materialized: false,
+          ),
+          Scenic::View.new(
+            name: "farewells",
+            definition: "SELECT 'bye'::text AS farewell;",
+            materialized: true,
           ),
         ])
       end


### PR DESCRIPTION
Sorting the views caused issues with dependent views. Consider:

```sql
CREATE VIEW parents AS SELECT * FROM posts;
CREATE VIEW children AS SELECT * FROM parents;
```

If we sort those by name when we dump to schema, `db:schema:load` will
try to create `children` before `parents`, which won't work due to its
dependency on `parents`.

Unfortunately, the `pg_views` table from which we source this schema
information does not give us any timestamps to go by to explicitly
order the views so we just rely on the order they are returned in by
Postgres. In limited testing, this seems sufficient and at any rate
should not be worse than arbitrarily and perhaps incorrectly ordering by
name.