### PR TITLE
Add support for updating materialized views

### DIFF
--- a/lib/scenic.rb
+++ b/lib/scenic.rb
@@ -7,6 +7,7 @@ require "scenic/schema_dumper"
 require "scenic/statements"
 require "scenic/version"
 require "scenic/view"
+require "scenic/index"
 
 # Scenic adds methods `ActiveRecord::Migration` to create and manage database
 # views in Rails applications.

--- a/lib/scenic/index.rb
+++ b/lib/scenic/index.rb
@@ -1,0 +1,36 @@
+module Scenic
+  # The in-memory representation of a database index.
+  #
+  # **This object is used internally by adapters and the schema dumper and is
+  # not intended to be used by application code. It is documented here for
+  # use by adapter gems.**
+  #
+  # @api extension
+  class Index
+    # The name of the object that has the index
+    # @return [String]
+    attr_reader :object_name
+
+    # The name of the index
+    # @return [String]
+    attr_reader :index_name
+
+    # The SQL statement that defines the index
+    # @return [String]
+    #
+    # @exmaple
+    #   "CREATE INDEX index_users_on_email ON users USING btree (email)"
+    attr_reader :definition
+
+    # Returns a new instance of Index
+    #
+    # @param object_name [String] The name of the object that has the index
+    # @param index_name [String] The name of the index
+    # @param definition [String] The SQL statements that defined the index
+    def initialize(object_name:, index_name:, definition:)
+      @object_name = object_name
+      @index_name = index_name
+      @definition = definition
+    end
+  end
+end

--- a/spec/smoke
+++ b/spec/smoke
@@ -32,7 +32,7 @@ writeToFileAndMigrateAndVerifySearchResults() {
   local expectedResult=$2
   local filePath=db/views/searches_v$version\.sql
   cp /dev/null $filePath
-  echo "SELECT '$expectedResult'::text AS results" >> $filePath
+  echo "SELECT '$expectedResult'::text AS results, 1 AS user_id" >> $filePath
   rake db:migrate
   echo "[success]"
   verifySearchResults $expectedResult
@@ -97,11 +97,24 @@ main() {
   rails runner "Search.refresh" || exit 1
   echo "[success]"
 
+  echo "add indexes to materialized view"
+  rails runner "ActiveRecord::Base.connection.execute 'CREATE INDEX searches_test_1 ON searches USING btree (results);'" || exit 1
+  rails runner "ActiveRecord::Base.connection.execute 'CREATE INDEX searches_test_2 ON searches USING btree (user_id);'" || exit 1
+  echo "[success]"
+
+  echo "update materialized view"
+  rails generate scenic:view search --materialized
+  echo "SELECT 'test'::text AS results" > db/views/searches_v02.sql
+  rake db:migrate
+  verifySearchResults 'test'
+
   echo "rake db:rollback"
+  rake db:rollback
   rake db:rollback
   echo "[success]"
 
-  echo "rails destroy scenic:view search --materialized"
+  echo "rails destroy scenic:model search --materialized"
+  rails destroy scenic:view search --materialized
   rails destroy scenic:model search --materialized
   [[ ! -f app/models/search.rb ]] || exit 1
   [[ ! -f db/views/searches_v01.sql ]] || exit 1


### PR DESCRIPTION
Updating materialized views used to be an error because providing a new
definition for a materialized view requires dropping and recreating it.
This will cause any indexes on the old materialized view to be dropped.
For this reason, we suggested that users manually `drop_view`,
`create_view` and `add_index`. This is a frustrating user experience.

This changes view updates to record any indexes that were in place
before the `drop_view` and then re-create those indexes once the new
materialized view is in place. Any indexes that are now invalid
(most-likely because the column no longer exists) will be dropped. This
behavior is similar to what happens when you alter the schema of a
table, so I do not believe it to be surprising.

We log the results of each index creation for the users information in
the migration output. For example:

```
== 20151228201117 UpdateSearchesToVersion2: migrating =========================
-- update_view(:searches, {:version=>2, :revert_to_version=>1, :materialized=>true})
   -> index 'searches_test_1' on 'searches' has been recreated
   -> index 'searches_test_2' on 'searches' is no longer valid and has been dropped.
   -> 0.0148s
== 20151228201117 UpdateSearchesToVersion2: migrated (0.0149s) ================
```

Closes #98