### PR TITLE
Add support for concurrent refreshes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ project codebases, issue trackers, chatrooms, and mailing lists.
 
 ## Setting Up for Development
 
-1. For the repository.
+1. Fork the repository.
 2. Run `bin/setup`, which will install dependencies and create the dummy
    application database.
 3. Run `rake` to verify that the tests pass.

--- a/README.md
+++ b/README.md
@@ -140,9 +140,14 @@ refreshes:
 
 ```ruby
 def self.refresh
-  Scenic.database.refresh_materialized_view(table_name)
+  Scenic.database.refresh_materialized_view(table_name, concurrently: false)
 end
 ```
+
+This will perform a non-concurrent refresh, locking the view for selects until
+the refresh is complete. You can avoid locking the view by passing
+`concurrently: true` but this requires your view to have at least one unique
+index that covers all rows.
 
 ## I don't need this view anymore. Make it go away.
 

--- a/lib/generators/scenic/model/templates/model.erb
+++ b/lib/generators/scenic/model/templates/model.erb
@@ -1,3 +1,3 @@
   def self.refresh
-    Scenic.database.refresh_materialized_view(table_name)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: false)
   end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -71,9 +71,19 @@ module Scenic
       # Refreshes a materialized view from its SQL schema.
       #
       # @param name The name of the materialized view to refresh.
+      # @param concurrently [Boolean] Whether the refreshs hould happen
+      #   concurrently or not. A concurrent refresh allows the view to be
+      #   refreshed without locking the view for select but requires that the
+      #   table have at least one unique index that covers all rows. Attempts to
+      #   refresh concurrently without a unique index will raise a descriptive
+      #   error.
       # @return [void]
-      def refresh_materialized_view(name)
-        execute "REFRESH MATERIALIZED VIEW #{name};"
+      def refresh_materialized_view(name, concurrently: false)
+        if concurrently
+          execute "REFRESH MATERIALIZED VIEW CONCURRENTLY #{name};"
+        else
+          execute "REFRESH MATERIALIZED VIEW #{name};"
+        end
       end
 
       # Caches indexes on the provided object before executing the block and

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -53,6 +53,17 @@ module Scenic
         end
       end
 
+      describe "#refresh_materialized_view" do
+        it "raises descriptive error if concurrent refresh is not possible" do
+          adapter = Postgres.new
+          adapter.create_materialized_view(:tests, "SELECT text 'hi' as text")
+
+          expect {
+            adapter.refresh_materialized_view(:tests, concurrently: true)
+          }.to raise_error(/Create a unique index with no WHERE clause/)
+        end
+      end
+
       it "finds views and builds Scenic::View objects" do
         adapter = Postgres.new
 


### PR DESCRIPTION
Concurrent refreshes allow the view to be selected from when it is being
refreshed, but require a unique index that covers all rows of the view.
For this reason, we cannot make concurrent refreshes the default.

The error returned by Postgres in situations where concurrent refreshes
are not possible is very descriptive. We test against this error both to
ensure we get a good error returned and to assert that Postgres received
the correct message.

The generated `self.refresh` model method has the `concurrently` option
hard-coded to `false` as this will work for all views and can be changed
manually where appropriate and desired. We thought about having
`refresh` take a `concurrently` option directly and passing that along,
but it seemed unlikely you'd want to sometimes refresh concurrently and
other times not.