### PR TITLE
Adding better error messages for materialized views

### DIFF
--- a/lib/scenic/adapters/postgres/connection.rb
+++ b/lib/scenic/adapters/postgres/connection.rb
@@ -24,6 +24,14 @@ module Scenic
           end
         end
 
+        # True if the connection supports concurrent refreshes of materialized
+        # views.
+        #
+        # @return [Boolean]
+        def supports_concurrent_refreshes?
+          postgresql_version >= 90400
+        end
+
         # An integer representing the version of Postgres we're connected to.
         #
         # postgresql_version is public in Rails 5, but protected in earlier

--- a/lib/scenic/adapters/postgres/errors.rb
+++ b/lib/scenic/adapters/postgres/errors.rb
@@ -1,0 +1,21 @@
+module Scenic
+  module Adapters
+    class Postgres
+      # Custom error classes for PostgreSQL specific errors
+      #
+      # These error classes are for more descriptive errors when users attempt
+      # to use materialized view features not supported by their current
+      # version.
+      class MaterializedViewsNotSupportedError < StandardError
+        def initialize
+          super("Materialized views require Postgres 9.3 or newer")
+        end
+      end
+      class ConcurrentRefreshesNotSupportedError < StandardError
+        def initialize
+          super("Concurrent materialized view refreshes require Postgres 9.4 or newer")
+        end
+      end
+    end
+  end
+end

--- a/spec/scenic/adapters/postgres/connection_spec.rb
+++ b/spec/scenic/adapters/postgres/connection_spec.rb
@@ -64,6 +64,16 @@ module Scenic
           expect(connection.postgresql_version).to eq 123
         end
       end
+
+      describe "#supports_concurrent_refresh" do
+        it "is true if postgres version is at least 9.4.0" do
+          base_connection = double("Connection", postgresql_version: 90400)
+
+          connection = Postgres::Connection.new(base_connection)
+
+          expect(connection.supports_concurrent_refreshes?).to be true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This commit adds more descriptive error messages for users when they try and use materialized views or refresh materialized views concurrently without a version of PostgreSQL that supports those operations (as mentioned in #110).

I thought about excluding checking for the possibility of an error in `drop_materalized_view` and `refresh_materalized_view` when `concurrently` is false, but for now I've decided to keep them in because they would be useful error messages for a user who was using those methods by mistake (like if they changed a particular relation from a materialized view to a view at one point and didn't change any code to refresh or drop those views).

This approach does duplicate some of the functionality that's in some protected methods in Rails, but allows us not to use those APIs and maintain compatibility with Rails 4.1.