### PR TITLE
Support versions of Postgres older than 9.3

### DIFF
--- a/lib/scenic/adapters/postgres/connection.rb
+++ b/lib/scenic/adapters/postgres/connection.rb
@@ -1,0 +1,49 @@
+module Scenic
+  module Adapters
+    class Postgres
+      # Decorates an ActiveRecord connection with methods that help determine
+      # the connections capabilities.
+      #
+      # Every attempt is made to use the versions of these methods defined by
+      # Rails where they are available and public before falling back to our own
+      # implementations for older Rails versions.
+      #
+      # @api private
+      class Connection < SimpleDelegator
+        # True if the connection supports materialized views.
+        #
+        # Delegates to the method of the same name if it is already defined on
+        # the connection. This is the case for Rails 4.2 or higher.
+        #
+        # @return [Boolean]
+        def supports_materialized_views?
+          if undecorated_connection.respond_to?(:supports_materialized_views?)
+            super
+          else
+            postgresql_version >= 90300
+          end
+        end
+
+        # An integer representing the version of Postgres we're connected to.
+        #
+        # postgresql_version is public in Rails 5, but protected in earlier
+        # versions.
+        #
+        # @return [Integer]
+        def postgresql_version
+          if undecorated_connection.respond_to?(:postgresql_version)
+            super
+          else
+            undecorated_connection.send(:postgresql_version)
+          end
+        end
+
+        private
+
+        def undecorated_connection
+          __getobj__
+        end
+      end
+    end
+  end
+end

--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -1,0 +1,58 @@
+module Scenic
+  module Adapters
+    class Postgres
+      # Fetches defined views from the postgres connection.
+      # @api private
+      class Views
+        def initialize(connection)
+          @connection = connection
+        end
+
+        # All of the views that this connection has defined.
+        #
+        # This will include materialized views if those are supported by the
+        # connection.
+        #
+        # @return [Array<Scenic::View>]
+        def all
+          (views.to_a + materialized_views.to_a).map do |result|
+            to_scenic_view(result)
+          end
+        end
+
+        private
+
+        attr_reader :connection
+
+        def views
+          connection.execute(<<-SQL)
+            SELECT viewname, definition, FALSE AS materialized
+            FROM pg_views
+            WHERE schemaname = ANY (current_schemas(false))
+            AND viewname NOT IN (SELECT extname FROM pg_extension)
+          SQL
+        end
+
+        def materialized_views
+          if connection.supports_materialized_views?
+            connection.execute(<<-SQL)
+              SELECT matviewname AS viewname, definition, TRUE AS materialized
+              FROM pg_matviews
+              WHERE schemaname = ANY (current_schemas(false))
+            SQL
+          else
+            []
+          end
+        end
+
+        def to_scenic_view(result)
+          Scenic::View.new(
+            name: result["viewname"],
+            definition: result["definition"].strip,
+            materialized: result["materialized"].in?(["t", true]),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/scenic/adapters/postgres/connection_spec.rb
+++ b/spec/scenic/adapters/postgres/connection_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+
+module Scenic
+  module Adapters
+    describe Postgres::Connection do
+      describe "supports_materialized_views?" do
+        context "supports_materialized_views? was defined on connection" do
+          it "uses the previously defined version" do
+            base_response = double("response from base connection")
+            base_connection = double(
+              "Connection",
+              supports_materialized_views?: base_response,
+            )
+
+            connection = Postgres::Connection.new(base_connection)
+
+            expect(connection.supports_materialized_views?).to be base_response
+          end
+        end
+
+        context "supports_materialized_views? is not already defined" do
+          it "is true if postgres version is at least than 9.3.0" do
+            base_connection = double("Connection", postgresql_version: 90300)
+
+            connection = Postgres::Connection.new(base_connection)
+
+            expect(connection.supports_materialized_views?).to be true
+          end
+
+          it "is false if postgres version is less than 9.3.0" do
+            base_connection = double("Connection", postgresql_version: 90299)
+
+            connection = Postgres::Connection.new(base_connection)
+
+            expect(connection.supports_materialized_views?).to be false
+          end
+        end
+      end
+
+      describe "#postgresql_version" do
+        it "uses the public method on the provided connection if defined" do
+          base_connection = Class.new do
+            def postgresql_version
+              123
+            end
+          end
+
+          connection = Postgres::Connection.new(base_connection.new)
+
+          expect(connection.postgresql_version).to eq 123
+        end
+
+        it "uses the protected method if the underlying method is not public" do
+          base_connection = Class.new do
+            protected
+
+            def postgresql_version
+              123
+            end
+          end
+
+          connection = Postgres::Connection.new(base_connection.new)
+
+          expect(connection.postgresql_version).to eq 123
+        end
+      end
+    end
+  end
+end

--- a/spec/scenic/adapters/postgres/views_spec.rb
+++ b/spec/scenic/adapters/postgres/views_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+module Scenic
+  module Adapters
+    describe Postgres::Views, :db do
+      it "does not query for materialized views if not supported" do
+        connection = ActiveRecord::Base.connection
+        allow(connection).to receive(:supports_materialized_views?)
+          .and_return(false)
+        ActiveRecord::Base.connection.execute(
+          "CREATE VIEW greetings AS SELECT text 'hi' AS greeting",
+        )
+        ActiveRecord::Base.connection.execute(
+          "CREATE MATERIALIZED VIEW farewells AS SELECT text 'bye' AS text",
+        )
+
+        views = Postgres::Views.new(connection).all
+
+        expect(views.map(&:name)).to eq ["greetings"]
+      end
+    end
+  end
+end

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 module Scenic
   module Adapters
     describe Postgres, :db do
-      describe "create_view" do
+      describe "#create_view" do
         it "successfully creates a view" do
           adapter = Postgres.new
 
@@ -13,7 +13,7 @@ module Scenic
         end
       end
 
-      describe "create_materialized_view" do
+      describe "#create_materialized_view" do
         it "successfully creates a materialized view" do
           adapter = Postgres.new
 
@@ -28,7 +28,7 @@ module Scenic
         end
       end
 
-      describe "drop_view" do
+      describe "#drop_view" do
         it "successfully drops a view" do
           adapter = Postgres.new
 
@@ -39,7 +39,7 @@ module Scenic
         end
       end
 
-      describe "drop_materialized_view" do
+      describe "#drop_materialized_view" do
         it "successfully drops a materialized view" do
           adapter = Postgres.new
 
@@ -64,28 +64,30 @@ module Scenic
         end
       end
 
-      it "finds views and builds Scenic::View objects" do
-        adapter = Postgres.new
+      describe "#views" do
+        it "returns the views defined on this connection" do
+          adapter = Postgres.new
 
-        ActiveRecord::Base.connection.execute(
-          "CREATE VIEW greetings AS SELECT text 'hi' AS greeting"
-        )
-        ActiveRecord::Base.connection.execute(
-          "CREATE MATERIALIZED VIEW farewells AS SELECT text 'bye' AS farewell"
-        )
+          ActiveRecord::Base.connection.execute(
+            "CREATE VIEW greetings AS SELECT text 'hi' AS greeting",
+          )
+          ActiveRecord::Base.connection.execute(
+            "CREATE MATERIALIZED VIEW farewells AS SELECT text 'bye' AS text",
+          )
 
-        expect(adapter.views).to eq([
-          Scenic::View.new(
-            name: "greetings",
-            definition: "SELECT 'hi'::text AS greeting;",
-            materialized: false,
-          ),
-          Scenic::View.new(
-            name: "farewells",
-            definition: "SELECT 'bye'::text AS farewell;",
-            materialized: true,
-          ),
-        ])
+          expect(adapter.views).to eq([
+            Scenic::View.new(
+              name: "greetings",
+              definition: "SELECT 'hi'::text AS greeting;",
+              materialized: false,
+            ),
+            Scenic::View.new(
+              name: "farewells",
+              definition: "SELECT 'bye'::text AS text;",
+              materialized: true,
+            ),
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
Postgres pre 9.3 does not support materialized views. Scenic can work
just fine for users of those versions, but it does not because the
`views` method on the adapter assumes that we can query `pg_matviews`
which does not exist on those older versions.

In this change, we introduce the concept of a decorated connection, with
the undecorated connection being injected into the adapter. This gives
us a place to decorate the connection with methods about its
capabilities. Some of these methods are defined in newer versions of
rails or are public in newer versions while being private in older
versions. We try to use the Rails versions of these methods where
possible before using our own implementation.

As part of this change, the code that looks up the views and returns
`Scenic::View` objects was extracted to its own class. This gave it some
space to grow and made for a more readable implemnentation than
otherwise possible.

Closes #112