### PR TITLE
Order views by Postgres oid

### DIFF
--- a/spec/scenic/adapters/postgres/views_spec.rb
+++ b/spec/scenic/adapters/postgres/views_spec.rb
@@ -3,20 +3,34 @@ require "spec_helper"
 module Scenic
   module Adapters
     describe Postgres::Views, :db do
-      it "does not query for materialized views if not supported" do
+      it "returns scenic view objects for plain old views" do
         connection = ActiveRecord::Base.connection
-        allow(connection).to receive(:supports_materialized_views?)
-          .and_return(false)
-        ActiveRecord::Base.connection.execute(
-          "CREATE VIEW greetings AS SELECT text 'hi' AS greeting",
-        )
-        ActiveRecord::Base.connection.execute(
-          "CREATE MATERIALIZED VIEW farewells AS SELECT text 'bye' AS text",
-        )
+        connection.execute <<-SQL
+          CREATE VIEW children AS SELECT text 'Elliot' AS name
+        SQL
 
         views = Postgres::Views.new(connection).all
+        first = views.first
 
-        expect(views.map(&:name)).to eq ["greetings"]
+        expect(views.size).to eq 1
+        expect(first.name).to eq "children"
+        expect(first.materialized).to be false
+        expect(first.definition).to eq "SELECT 'Elliot'::text AS name;"
+      end
+
+      it "returns scenic view objects for materialized views" do
+        connection = ActiveRecord::Base.connection
+        connection.execute <<-SQL
+          CREATE MATERIALIZED VIEW children AS SELECT text 'Owen' AS name
+        SQL
+
+        views = Postgres::Views.new(connection).all
+        first = views.first
+
+        expect(views.size).to eq 1
+        expect(first.name).to eq "children"
+        expect(first.materialized).to be true
+        expect(first.definition).to eq "SELECT 'Owen'::text AS name;"
       end
     end
   end


### PR DESCRIPTION
Our previous strategy of:

1. Relying on postgres to give us the views from `pg_views` and
   `pg_matviews` in the correct order
2. Always dumping materialized views last

was incorrect on both counts. Those tables have no specific ordering so
the results can come back in any order. Also, we can have views that
depend on materialized views.

We need to get all of the views - materialized and otherwise - from a
single query and we need them to be ordered in the same order they were
created.

I inspected the definitions of `pg_views` and `pg_matviews` and noticed
they are both built from pg_class. Querying on that table gives us a way
to get both the views and materialized views in a single query. Ordering
by 'oid' is the simplest way to order them by insertion order. Dropping
a view that depends on a child view also requires dropping that child
view, so ordering in this manner should be sufficient.

This technically means we don't need the connection decorator I
introduced in the previous change, but we know we will be using that
functionality very soon in another change, so I'm leaving it be for now.

I ran the improved test of `#views` in the `postgres_spec` hundreds of
times and got a consistent, valid order every time.