### PR TITLE
Refactor view updates

### DIFF
--- a/lib/scenic/adapters/postgres/index_reapplication.rb
+++ b/lib/scenic/adapters/postgres/index_reapplication.rb
@@ -1,0 +1,71 @@
+module Scenic
+  module Adapters
+    class Postgres
+      # Updatine a materialized view causes the view to be dropped and
+      # recreated. This causes any associated indexes to be dropped as well.
+      # This object can be used to capture the existing indexes before the drop
+      # and then reapply appropriate indexes following the create.
+      #
+      # @api private
+      class IndexReapplication
+        # Creates the index reapplication object.
+        #
+        # @param connection [Connection] The connection to execute SQL against.
+        # @param speaker [#say] (ActiveRecord::Migration) The object used for
+        #   logging the results of reapplying indexes.
+        def initialize(connection:, speaker: ActiveRecord::Migration)
+          @connection = connection
+          @speaker = speaker
+        end
+
+        # Caches indexes on the provided object before executing the block and
+        # then reapplying the indexes. Each recreated or skipped index is
+        # announced to STDOUT by default. This can be overridden in the
+        # constructor.
+        #
+        # @param name The name of the object we are reapplying indexes on.
+        # @yield Operations to perform before reapplying indexes.
+        #
+        # @return [void]
+        def on(name)
+          indexes = Indexes.new(connection: connection).on(name)
+
+          yield
+
+          indexes.each(&method(:try_index_create))
+        end
+
+        private
+
+        attr_reader :connection, :speaker
+
+        def try_index_create(index)
+          success = with_savepoint(index.index_name) do
+            connection.execute(index.definition)
+          end
+
+          if success
+            say "index '#{index.index_name}' on '#{index.object_name}' has been recreated"
+          else
+            say "index '#{index.index_name}' on '#{index.object_name}' is no longer valid and has been dropped."
+          end
+        end
+
+        def with_savepoint(name)
+          connection.execute("SAVEPOINT #{name}")
+          yield
+          connection.execute("RELEASE SAVEPOINT #{name}")
+          true
+        rescue
+          connection.execute("ROLLBACK TO SAVEPOINT #{name}")
+          false
+        end
+
+        def say(message)
+          subitem = true
+          speaker.say(message, subitem)
+        end
+      end
+    end
+  end
+end

--- a/lib/scenic/adapters/postgres/indexes.rb
+++ b/lib/scenic/adapters/postgres/indexes.rb
@@ -1,0 +1,52 @@
+module Scenic
+  module Adapters
+    class Postgres
+      # Fetches indexes on objects from the Postgres connection.
+      #
+      # @api private
+      class Indexes
+        def initialize(connection:)
+          @connection = connection
+        end
+
+        # Indexes on the provided object.
+        #
+        # @param name [String] The name of the object we want indexes from.
+        # @return [Array<Scenic::Index>]
+        def on(name)
+          indexes_on(name).map(&method(:index_from_database))
+        end
+
+        private
+
+        attr_reader :connection
+
+        def indexes_on(name)
+          connection.execute(<<-SQL)
+            SELECT
+              t.relname as object_name,
+              i.relname as index_name,
+              pg_get_indexdef(d.indexrelid) AS definition
+            FROM pg_class t
+            INNER JOIN pg_index d ON t.oid = d.indrelid
+            INNER JOIN pg_class i ON d.indexrelid = i.oid
+            LEFT JOIN pg_namespace n ON n.oid = i.relnamespace
+            WHERE i.relkind = 'i'
+              AND d.indisprimary = 'f'
+              AND t.relname = '#{name}'
+              AND n.nspname = ANY (current_schemas(false))
+            ORDER BY i.relname
+          SQL
+        end
+
+        def index_from_database(result)
+          Scenic::Index.new(
+            object_name: result["object_name"],
+            index_name: result["index_name"],
+            definition: result["definition"],
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -80,9 +80,12 @@ module Scenic
         raise ArgumentError, "version is required"
       end
 
-      Scenic.database.reapplying_indexes(on: name) do
-        drop_view(name, revert_to_version: revert_to_version, materialized: materialized)
-        create_view(name, version: version, materialized: materialized)
+      sql_definition = definition(name, version)
+
+      if materialized
+        Scenic.database.update_materialized_view(name, sql_definition)
+      else
+        Scenic.database.update_view(name, sql_definition)
       end
     end
 

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -65,19 +65,27 @@ module Scenic
     end
 
     describe "update_view" do
-      it "updates the view version, reapplying indexes as needed" do
+      it "updates the view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
           .with(:name, 3)
           .and_return(definition)
-        allow(Scenic.database).to receive(:reapplying_indexes)
-          .with(on: :name)
-          .and_yield
 
         connection.update_view(:name, version: 3)
 
-        expect(Scenic.database).to have_received(:drop_view).with(:name)
-        expect(Scenic.database).to have_received(:create_view)
+        expect(Scenic.database).to have_received(:update_view)
+          .with(:name, definition.to_sql)
+      end
+
+      it "updates the materialized view in the database" do
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+          .with(:name, 3)
+          .and_return(definition)
+
+        connection.update_view(:name, version: 3, materialized: true)
+
+        expect(Scenic.database).to have_received(:update_materialized_view)
           .with(:name, definition.to_sql)
       end
 


### PR DESCRIPTION
This introduces `update_view` and `update_materialized_view` as methods
on the Postgres adapter. The schema statements previously expressed
these methods in terms of `drop_view` and `create_view`, wrapped in a
call to our index reapplication code. Breaking these methods out allows
other adapters to implement these as they see fit, and also allows us to
make that index reapplication index a private implementation detail of
the adapter.

I also extracted an indexes query object (like the views query object)
and the index reapplication object to clean up the private methods on
the adapter itself.