### PR TITLE
Make API docs for Postgres adapter public

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,4 @@
 --hide-api private
---hide-api extension
 --exclude templates
 --markup markdown
 --markup-provider redcarpet

--- a/lib/scenic/configuration.rb
+++ b/lib/scenic/configuration.rb
@@ -28,7 +28,7 @@ module Scenic
   # @yieldparam [Scenic::Configuration] config current Scenic config
   # ```
   # Scenic.configure do |config|
-  #   config.database = Scenic::Adapters::Postgres
+  #   config.database = Scenic::Adapters::Postgres.new
   # end
   # ```
   def self.configure


### PR DESCRIPTION
While we don't expect people to call these methods directly, the
documentation they offer is likely to answer questions on how Scenic
interfaces directly with Postgres.

Additionally, this is the only place `#refresh_materialized_view` is
documented. This was already a public method (we put it in generators),
so documenting it seems wise.

The method names in use in the adapter are often duplicates of the
method names exposed in migrations. For that reason, I specifically
linked from the adapter method to its corresponding method in the schema
statements.