### PR TITLE
Adding support for views in schemas other than public

### DIFF
--- a/lib/generators/scenic/view/templates/db/migrate/create_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/create_view.erb
@@ -1,5 +1,5 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
-    create_view :<%= plural_name %><%= ", materialized: true" if materialized? %>
+    create_view <%= formatted_plural_name %><%= ", materialized: true" if materialized? %>
   end
 end

--- a/lib/generators/scenic/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/update_view.erb
@@ -1,12 +1,12 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
   <%- if materialized? -%>
-    update_view :<%= plural_name %>,
+    update_view <%= formatted_plural_name %>,
       version: <%= version %>,
       revert_to_version: <%= previous_version %>,
       materialized: true
   <%- else -%>
-    update_view :<%= plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
+    update_view <%= formatted_plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
   <%- end -%>
   end
 end

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -56,7 +56,7 @@ module Scenic
 
         def migration_class_name
           if creating_new_view?
-            super
+            "Create#{class_name.gsub('.', '').pluralize}"
           else
             "Update#{class_name.pluralize}ToVersion#{version}"
           end
@@ -85,8 +85,20 @@ module Scenic
         Scenic::Definition.new(plural_file_name, previous_version)
       end
 
+      def plural_file_name
+        @plural_file_name ||= file_name.pluralize.gsub(".", "_")
+      end
+
       def destroying?
         behavior == :revoke
+      end
+
+      def formatted_plural_name
+        if plural_name.include?(".")
+          "\"#{plural_name}\""
+        else
+          ":#{plural_name}"
+        end
       end
 
       def destroying_initial_view?

--- a/spec/generators/scenic/view/view_generator_spec.rb
+++ b/spec/generators/scenic/view/view_generator_spec.rb
@@ -36,4 +36,16 @@ describe Scenic::Generators::ViewGenerator, :generator do
       expect(migration).to contain "materialized: true"
     end
   end
+
+  context "for views created in a schema other than 'public'" do
+    it "creates view definition and migration files" do
+      migration = file("db/migrate/create_non_public_searches.rb")
+      view_definition = file("db/views/non_public_searches_v01.sql")
+
+      run_generator ["non_public.search"]
+
+      expect(migration).to be_a_migration
+      expect(view_definition).to exist
+    end
+  end
 end


### PR DESCRIPTION
I ran into an issue where I wanted to create a view in a schema on Postgres other than the `public` schema, and the generator gave me files that weren't quite what I needed. It wasn't all that tricky to fix them, but I figured it would be easy enough to add in support for them for good measure.

Basically the only thing we had to do was to change the generator, and specifically we needed to override the Rails default method for `plural_file_name` so that it removed the `.` needed in the table definition when the schema was included. I also had to change the table name in the actual migration from a symbol to a string to support having a `.` in the name.