### PR TITLE
Add last method error workaround to FAQs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ class People < ActiveRecord::Base
   self.primary_key = :id
 end
 ```
+**When I query a view-backed model with `last` method I get an error. What gives?**
+
+Your view cannot have a primary key, but ActiveRecored's `last` method uses ordering by primary key to get the last record. 
+To get this working you must explicitly set the primary key column on your model like so:
+
+```ruby
+class People < ActiveRecord::Base
+  self.primary_key = :id
+end
+```
+
 
 **Why is my view missing columns from the underlying table?**
 


### PR DESCRIPTION
<img width="1001" alt="screen shot 2016-01-13 at 20 18 41" src="https://cloud.githubusercontent.com/assets/7427365/12305015/e4248a02-ba32-11e5-8549-c897fe351e68.png">

```last``` method uses ```ORDER BY id DESC``` to find last row. When we explicitly don't set primary key in our model, there is error :(
Not sure if this FAQ should go in separate section or we could somehow stick it with ```find``` FAQ, but for me this is more readable :) 
