### PR TITLE
Get a fresh connection for all operations

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -27,15 +27,15 @@ module Scenic
       # {Scenic.configure} is not required, but the example below shows how one
       # would explicitly set it.
       #
-      # @param connection The database connection the adapter should use. This
-      #   defaults to `ActiveRecord::Base.connection`
+      # @param [#connection] connectable An object that returns the connection
+      #   for Scenic to use. Defaults to `ActiveRecord::Base`.
       #
       # @example
       #  Scenic.configure do |config|
       #    config.adapter = Scenic::Adapters::Postgres.new
       #  end
-      def initialize(connection = ActiveRecord::Base.connection)
-        @connection = Connection.new(connection)
+      def initialize(connectable = ActiveRecord::Base)
+        @connectable = connectable
       end
 
       # Returns an array of views in the database.
@@ -183,8 +183,12 @@ module Scenic
 
       private
 
-      attr_reader :connection
+      attr_reader :connectable
       delegate :execute, :quote_table_name, to: :connection
+
+      def connection
+        Connection.new(connectable.connection)
+      end
 
       def raise_unless_materialized_views_supported
         unless connection.supports_materialized_views?

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -29,7 +29,8 @@ module Scenic
 
         it "raises an exception if the version of PostgreSQL is too old" do
           connection = double("Connection", supports_materialized_views?: false)
-          adapter = Postgres.new(connection)
+          connectable = double("Connectable", connection: connection)
+          adapter = Postgres.new(connectable)
           err = Scenic::Adapters::Postgres::MaterializedViewsNotSupportedError
 
           expect { adapter.create_materialized_view("greetings", "select 1") }
@@ -63,7 +64,8 @@ module Scenic
 
         it "raises an exception if the version of PostgreSQL is too old" do
           connection = double("Connection", supports_materialized_views?: false)
-          adapter = Postgres.new(connection)
+          connectable = double("Connectable", connection: connection)
+          adapter = Postgres.new(connectable)
           err = Scenic::Adapters::Postgres::MaterializedViewsNotSupportedError
 
           expect { adapter.drop_materialized_view("greetings") }
@@ -74,7 +76,8 @@ module Scenic
       describe "#refresh_materialized_view" do
         it "raises an exception if the version of PostgreSQL is too old" do
           connection = double("Connection", supports_materialized_views?: false)
-          adapter = Postgres.new(connection)
+          connectable = double("Connectable", connection: connection)
+          adapter = Postgres.new(connectable)
           err = Scenic::Adapters::Postgres::MaterializedViewsNotSupportedError
 
           expect { adapter.refresh_materialized_view(:tests) }
@@ -93,7 +96,8 @@ module Scenic
 
           it "raises an exception if the version of PostgreSQL is too old" do
             connection = double("Connection", postgresql_version: 90300)
-            adapter = Postgres.new(connection)
+            connectable = double("Connectable", connection: connection)
+            adapter = Postgres.new(connectable)
             e = Scenic::Adapters::Postgres::ConcurrentRefreshesNotSupportedError
 
             expect {


### PR DESCRIPTION
The Postgres adapter was previously accepting an ActiveRecord connection
directly. In some operations, this resulted in Scenic attempting to use
a connection that had already been closed by Rails.

Instead of taking a connection directly, we now take something that
responds to a `connection`, returning a fresh connection.