### PR TITLE
Test against 2.1.8 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ sudo: false
 rvm:
   - 2.3.0
   - 2.2.4
-  - 2.1.7
+  - 2.1.8
 gemfile:
   - gemfiles/rails40.gemfile
   - gemfiles/rails41.gemfile
@@ -27,5 +27,5 @@ gemfile:
   - gemfiles/rails50.gemfile
 matrix:
   exclude:
-    - rvm: 2.1.7
+    - rvm: 2.1.8
       gemfile: gemfiles/rails50.gemfile


### PR DESCRIPTION
The travis issue with Ruby 2.1.8 appears to be fixed.