### PR TITLE
Add update_view_replace migration statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,49 @@ Scenic detected that we already had an existing `search_results` view at version
 update to the version 2 schema. All that's left for you to do is tweak the
 schema in the new definition and run the `update_view` migration.
 
+## What if I want to change a view without dropping it?
+
+The `update_view` statement used by default will drop your view then create
+a new version of it.
+
+This is not desirable when you have complicated hierarchies of views, especially
+when some of those views may be materialized and take a long time to recreate.
+
+You can use `replace_view` to generate a CREATE OR REPLACE VIEW SQL statement.
+
+See postgresql documentation on how this works:
+http://www.postgresql.org/docs/current/static/sql-createview.html
+
+To start replacing a view run the generator like for a regular change:
+
+```sh
+$ rails generate scenic:view search_results
+      create  db/views/search_results_v02.sql
+      create  db/migrate/[TIMESTAMP]_update_search_results_to_version_2.rb
+```
+
+Now, edit the migration. It should look something like:
+
+```ruby
+class UpdateSearchResultsToVersion2 < ActiveRecord::Migration
+  def change
+    update_view :search_results, version: 2, revert_to_version: 1
+  end
+end
+```
+
+Update it to use replace view:
+
+```ruby
+class UpdateSearchResultsToVersion2 < ActiveRecord::Migration
+  def change
+    replace_view :search_results, version: 2, revert_to_version: 1
+  end
+end
+```
+
+Now you can run the migration like normal.
+
 ## Can I use this view to back a model?
 
 You bet! Using view-backed models can help promote concepts hidden in your

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -81,6 +81,29 @@ module Scenic
         create_view(name, sql_definition)
       end
 
+      # Updates a view in the database using `CREATE OR REPLACE VIEW`.
+      #
+      # This results in a `CREATE OR REPLACE VIEW`. Most of the time the
+      # explicitness of the two step process used in {#update_view} is preferred to
+      # `CREATE OR REPLACE VIEW` because the former ensures that the view you are trying
+      # to update did, in fact, already exist. Additionally, `CREATE OR REPLACE
+      # VIEW` is allowed only to add new columns to the end of an existing
+      # view schema. Existing columns cannot be re-ordered, removed, or have
+      # their types changed. Drop and create overcomes this limitation as well.
+      #
+      # However, when there is a tangled dependency tree `CREATE OR REPLACE VIEW` can
+      # be preferable.
+      #
+      # This is typically called in a migration via {Statements#update_view_replace}.
+      #
+      # @param name The name of the view to update
+      # @param sql_definition The SQL schema for the updated view.
+      #
+      # @return [void]
+      def update_view_replace(name, sql_definition)
+        execute "CREATE OR REPLACE VIEW #{quote_table_name(name)} AS #{sql_definition};"
+      end
+
       # Drops the named view from the database
       #
       # This is typically called in a migration via {Statements#drop_view}.

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -81,26 +81,28 @@ module Scenic
         create_view(name, sql_definition)
       end
 
-      # Updates a view in the database using `CREATE OR REPLACE VIEW`.
+      # Replaces a view in the database using `CREATE OR REPLACE VIEW`.
       #
       # This results in a `CREATE OR REPLACE VIEW`. Most of the time the
-      # explicitness of the two step process used in {#update_view} is preferred to
-      # `CREATE OR REPLACE VIEW` because the former ensures that the view you are trying
-      # to update did, in fact, already exist. Additionally, `CREATE OR REPLACE
-      # VIEW` is allowed only to add new columns to the end of an existing
-      # view schema. Existing columns cannot be re-ordered, removed, or have
-      # their types changed. Drop and create overcomes this limitation as well.
+      # explicitness of the two step process used in {#update_view} is preferred
+      # to `CREATE OR REPLACE VIEW` because the former ensures that the view you
+      # are trying to update did, in fact, already exist. Additionally,
+      # `CREATE OR REPLACE VIEW` is allowed only to add new columns to the end
+      # of an existing view schema. Existing columns cannot be re-ordered,
+      # removed, or have their types changed. Drop and create overcomes this
+      # limitation as well.
       #
-      # However, when there is a tangled dependency tree `CREATE OR REPLACE VIEW` can
-      # be preferable.
+      # However, when there is a tangled dependency tree
+      # `CREATE OR REPLACE VIEW` can be preferable.
       #
-      # This is typically called in a migration via {Statements#update_view_replace}.
+      # This is typically called in a migration via
+      # {Statements#replace_view}.
       #
       # @param name The name of the view to update
       # @param sql_definition The SQL schema for the updated view.
       #
       # @return [void]
-      def update_view_replace(name, sql_definition)
+      def replace_view(name, sql_definition)
         execute "CREATE OR REPLACE VIEW #{quote_table_name(name)} AS #{sql_definition};"
       end
 

--- a/lib/scenic/command_recorder.rb
+++ b/lib/scenic/command_recorder.rb
@@ -15,6 +15,10 @@ module Scenic
       record(:update_view, args)
     end
 
+    def update_view_replace(*args)
+      record(:update_view_replace, args)
+    end
+
     def invert_create_view(args)
       [:drop_view, args]
     end
@@ -25,6 +29,10 @@ module Scenic
 
     def invert_update_view(args)
       perform_scenic_inversion(:update_view, args)
+    end
+
+    def invert_update_view_replace(args)
+      perform_scenic_inversion(:update_view_replace, args)
     end
 
     private

--- a/lib/scenic/command_recorder.rb
+++ b/lib/scenic/command_recorder.rb
@@ -15,8 +15,8 @@ module Scenic
       record(:update_view, args)
     end
 
-    def update_view_replace(*args)
-      record(:update_view_replace, args)
+    def replace_view(*args)
+      record(:replace_view, args)
     end
 
     def invert_create_view(args)
@@ -31,8 +31,8 @@ module Scenic
       perform_scenic_inversion(:update_view, args)
     end
 
-    def invert_update_view_replace(args)
-      perform_scenic_inversion(:update_view_replace, args)
+    def invert_replace_view(args)
+      perform_scenic_inversion(:replace_view, args)
     end
 
     private

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -94,7 +94,7 @@ module Scenic
     # The existing view is replaced using the supplied `version`
     # parameter.
     #
-    # Does not work with materialized views, no parameter for that is provided!
+    # Does not work with materialized views due to lack of database support.
     #
     # @param name [String, Symbol] The name of the database view.
     # @param version [Fixnum] The version number of the view.
@@ -105,9 +105,13 @@ module Scenic
     # @example
     #   replace_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def replace_view(name, version: nil, revert_to_version: nil)
+    def replace_view(name, version: nil, revert_to_version: nil, materialized: false)
       if version.blank?
         raise ArgumentError, "version is required"
+      end
+
+      if materialized
+        raise ArgumentError, "Cannot replace materialized views"
       end
 
       sql_definition = definition(name, version)

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -91,7 +91,7 @@ module Scenic
 
     # Update a database view to a new version using `CREATE OR REPLACE VIEW`.
     #
-    # The existing view is created/replaced using the supplied `version`
+    # The existing view is replaced using the supplied `version`
     # parameter.
     #
     # Does not work with materialized views, no parameter for that is provided!
@@ -103,16 +103,16 @@ module Scenic
     # @return The database response from executing the create statement.
     #
     # @example
-    #   update_view_replace :engagement_reports, version: 3, revert_to_version: 2
+    #   replace_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def update_view_replace(name, version: nil, revert_to_version: nil)
+    def replace_view(name, version: nil, revert_to_version: nil)
       if version.blank?
         raise ArgumentError, "version is required"
       end
 
       sql_definition = definition(name, version)
 
-      Scenic.database.update_view_replace(name, sql_definition)
+      Scenic.database.replace_view(name, sql_definition)
     end
 
     private

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -89,6 +89,32 @@ module Scenic
       end
     end
 
+    # Update a database view to a new version using `CREATE OR REPLACE VIEW`.
+    #
+    # The existing view is created/replaced using the supplied `version`
+    # parameter.
+    #
+    # Does not work with materialized views, no parameter for that is provided!
+    #
+    # @param name [String, Symbol] The name of the database view.
+    # @param version [Fixnum] The version number of the view.
+    # @param revert_to_version [Fixnum] The version number to rollback to on
+    #   `rake db rollback`
+    # @return The database response from executing the create statement.
+    #
+    # @example
+    #   update_view_replace :engagement_reports, version: 3, revert_to_version: 2
+    #
+    def update_view_replace(name, version: nil, revert_to_version: nil)
+      if version.blank?
+        raise ArgumentError, "version is required"
+      end
+
+      sql_definition = definition(name, version)
+
+      Scenic.database.update_view_replace(name, sql_definition)
+    end
+
     private
 
     def definition(name, version)

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -44,11 +44,13 @@ module Scenic
 
           adapter.create_view("greetings", "SELECT text 'hi' AS greeting")
 
-          expect(adapter.views.first.definition).to eql "SELECT 'hi'::text AS greeting;"
+          view = adapter.views.first.definition
+          expect(view).to eql "SELECT 'hi'::text AS greeting;"
 
           adapter.replace_view("greetings", "SELECT text 'hello' AS greeting")
 
-          expect(adapter.views.first.definition).to eql "SELECT 'hello'::text AS greeting;"
+          view = adapter.views.first.definition
+          expect(view).to eql "SELECT 'hello'::text AS greeting;"
         end
       end
 

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -38,6 +38,20 @@ module Scenic
         end
       end
 
+      describe "#replace_view" do
+        it "successfully replaces a view" do
+          adapter = Postgres.new
+
+          adapter.create_view("greetings", "SELECT text 'hi' AS greeting")
+
+          expect(adapter.views.first.definition).to eql "SELECT 'hi'::text AS greeting;"
+
+          adapter.replace_view("greetings", "SELECT text 'hello' AS greeting")
+
+          expect(adapter.views.first.definition).to eql "SELECT 'hello'::text AS greeting;"
+        end
+      end
+
       describe "#drop_view" do
         it "successfully drops a view" do
           adapter = Postgres.new

--- a/spec/scenic/command_recorder_spec.rb
+++ b/spec/scenic/command_recorder_spec.rb
@@ -65,6 +65,32 @@ describe Scenic::CommandRecorder do
     end
   end
 
+  describe "#replace_view" do
+    it "records the replaced view" do
+      args = [:users, { version: 2 }]
+
+      recorder.replace_view(*args)
+
+      expect(recorder.commands).to eq [[:replace_view, args, nil]]
+    end
+
+    it "reverts to replace_view with the specified revert_to_version" do
+      args = [:users, { version: 2, revert_to_version: 1 }]
+      revert_args = [:users, { version: 1 }]
+
+      recorder.revert { recorder.replace_view(*args) }
+
+      expect(recorder.commands).to eq [[:replace_view, revert_args]]
+    end
+
+    it "raises when reverting without revert_to_version set" do
+      args = [:users, { version: 42, another_argument: 1 }]
+
+      expect { recorder.revert { recorder.replace_view(*args) } }
+        .to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+
   def recorder
     @recorder ||= ActiveRecord::Migration::CommandRecorder.new
   end

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -95,6 +95,25 @@ module Scenic
       end
     end
 
+    describe "replace_view" do
+      it "replaces the view in the database" do
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+                              .with(:name, 3)
+                              .and_return(definition)
+
+        connection.replace_view(:name, version: 3)
+
+        expect(Scenic.database).to have_received(:replace_view)
+                                    .with(:name, definition.to_sql)
+      end
+
+      it "raises an error if not supplied a version" do
+        expect { connection.replace_view :views }
+          .to raise_error(ArgumentError, /version is required/)
+      end
+    end
+
     def connection
       Class.new { extend Statements }
     end

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -108,6 +108,17 @@ module Scenic
                                     .with(:name, definition.to_sql)
       end
 
+      it "fails to replace the materialized view in the database" do
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+                              .with(:name, 3)
+                              .and_return(definition)
+
+        expect do
+          connection.replace_view(:name, version: 3, materialized: true)
+        end.to raise_error(ArgumentError, /Cannot replace materialized views/)
+      end
+
       it "raises an error if not supplied a version" do
         expect { connection.replace_view :views }
           .to raise_error(ArgumentError, /version is required/)

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -99,20 +99,20 @@ module Scenic
       it "replaces the view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-                              .with(:name, 3)
-                              .and_return(definition)
+          .with(:name, 3)
+          .and_return(definition)
 
         connection.replace_view(:name, version: 3)
 
         expect(Scenic.database).to have_received(:replace_view)
-                                    .with(:name, definition.to_sql)
+          .with(:name, definition.to_sql)
       end
 
       it "fails to replace the materialized view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-                              .with(:name, 3)
-                              .and_return(definition)
+          .with(:name, 3)
+          .and_return(definition)
 
         expect do
           connection.replace_view(:name, version: 3, materialized: true)


### PR DESCRIPTION
Despite the fact that drop_view, create_view is usually the better
choice there are some situations where CREATE OR REPLACE VIEW can be
better. An example is when you have a complicated dependency tree
between your views or when the view is depended upon by a slow
materialized view.

This commit adds a update_view_replace migration statement (and
associated code) that uses CREATE OR REPLACE VIEW instead of
dropping and creating the view.

I understand you had reasons for not having this functionality, so I have made this pull request early. If this functionality is just not wanted, I'd rather not waste my time making a better patch.

Assuming you are open to adding this feature, I will spend the time working on updating tests, docs, etc for the new method.

I am also open to naming it something else of course, this is just the first name that came to mind.

A possibility is adding a flag to update_view but I felt this was more clear.

Edit: We "needed" this for work and currently are using this for a feature branch.