### PR TITLE
Singularize file_path when injecting into class

### DIFF
--- a/lib/generators/scenic/model/model_generator.rb
+++ b/lib/generators/scenic/model/model_generator.rb
@@ -11,12 +11,12 @@ module Scenic
       source_root File.expand_path("../templates", __FILE__)
 
       def invoke_rails_model_generator
-        invoke "model", [name], options.merge(migration: false)
+        invoke "model", [file_path.singularize], options.merge(migration: false)
       end
 
       def inject_model_methods
         if materialized? && generating?
-          inject_into_class "app/models/#{file_path}.rb", class_name do
+          inject_into_class "app/models/#{file_path.singularize}.rb", class_name do
             evaluate_template("model.erb")
           end
         end

--- a/spec/acceptance/user_manages_views_spec.rb
+++ b/spec/acceptance/user_manages_views_spec.rb
@@ -49,6 +49,10 @@ describe "User manages views" do
     successfully "rails destroy scenic:model child"
   end
 
+  it "handles plural view names gracefully during generation" do
+    successfully "rails generate scenic:model search_results --materialized"
+  end
+
   def successfully(command)
     `RAILS_ENV=test #{command}`
     expect($?.exitstatus).to eq(0), "'#{command}' was unsuccessful"


### PR DESCRIPTION
Railties assumes that `file_name`, set in
[`assign_names!`](https://github.com/rails/rails/blob/4a446220a67e115c04a2b562dce92981a8e18c78/railties/lib/rails/generators/named_base.rb#L177-L181)
as a derivative of `name` which can be plural or singular, will always be
singular when it implicitly aliases it in
[`singular_name`](https://github.com/rails/rails/blob/4a446220a67e115c04a2b562dce92981a8e18c78/railties/lib/rails/generators/named_base.rb#L36-L38).

This is really a rails/rails issue, but to resolve #148 for ourselves we'll
call `singularize` on `file_path` which inherits this assumption. It seems to
me that the solution really would be to singularize `name` in NamedBase before
calling `assign_names` since every instance of
`plural_*` calls pluralize.