### PR TITLE
Adds view's namespace to the SchemaDumper

### DIFF
--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -43,8 +43,10 @@ module Scenic
     # @api private
     def to_schema
       materialized_option = materialized ? "materialized: true, " : ""
+      safe_to_symbolize_name = name.include?(".") ? "'#{name}'" : name
+
       <<-DEFINITION
-  create_view :#{name}, #{materialized_option} sql_definition: <<-\SQL
+  create_view :#{safe_to_symbolize_name}, #{materialized_option} sql_definition: <<-\SQL
     #{definition.indent(2)}
   SQL
 

--- a/spec/scenic/adapters/postgres_spec.rb
+++ b/spec/scenic/adapters/postgres_spec.rb
@@ -137,6 +137,27 @@ module Scenic
             "people_with_names",
           ]
         end
+
+        context "with views in non public schemas" do
+          it "returns also the non public views" do
+            adapter = Postgres.new
+
+            ActiveRecord::Base.connection.execute <<-SQL
+              CREATE VIEW parents AS SELECT text 'Joe' AS name
+            SQL
+
+            ActiveRecord::Base.connection.execute <<-SQL
+              CREATE SCHEMA scenic;
+              CREATE VIEW scenic.parents AS SELECT text 'Maarten' AS name;
+              SET search_path TO scenic, public;
+            SQL
+
+            expect(adapter.views.map(&:name)).to eq [
+              "parents",
+              "scenic.parents",
+            ]
+          end
+        end
       end
     end
   end

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -20,4 +20,20 @@ describe Scenic::SchemaDumper, :db do
 
     expect(Search.first.haystack).to eq "needle"
   end
+
+  context "with views in non public schemas" do
+    it "dumps a create_view including namespace for a view in the database" do
+      view_definition = "SELECT 'needle'::text AS haystack"
+      Search.connection.execute "CREATE SCHEMA scenic; SET search_path TO scenic, public"
+      Search.connection.create_view :"scenic.searches", sql_definition: view_definition
+      stream = StringIO.new
+
+      ActiveRecord::SchemaDumper.dump(Search.connection, stream)
+
+      output = stream.string
+      expect(output).to include "create_view :'scenic.searches',"
+
+      Search.connection.drop_view :'scenic.searches'
+    end
+  end
 end


### PR DESCRIPTION
This adds the view's namespace when dumping a view. This is useful when views live in another schema than `public`. Before this change the dumper would dump `thoughtbot.scenic` as `scenic`. In our case this would collide with our `scenic` view that's living in the `public` namespace.