### PR TITLE
Allow custom path to be used for migration and view files

### DIFF
--- a/lib/generators/scenic/custom_pathable.rb
+++ b/lib/generators/scenic/custom_pathable.rb
@@ -8,8 +8,8 @@ module Scenic
         class_option :custom_path,
           type: :string,
           required: false,
-          desc: 'Sets the path for the view',
-          default: ''
+          desc: "Sets the path for the view",
+          default: ""
       end
 
       private

--- a/lib/generators/scenic/custom_pathable.rb
+++ b/lib/generators/scenic/custom_pathable.rb
@@ -1,0 +1,26 @@
+module Scenic
+  module Generators
+    # @api private
+    module CustomPathable
+      extend ActiveSupport::Concern
+
+      included do
+        class_option :custom_path,
+          type: :string,
+          required: false,
+          desc: 'Sets the path for the view',
+          default: ''
+      end
+
+      private
+
+      def custom_path
+        options[:custom_path].to_s
+      end
+
+      def custom_path?
+        custom_path.present?
+      end
+    end
+  end
+end

--- a/lib/generators/scenic/model/model_generator.rb
+++ b/lib/generators/scenic/model/model_generator.rb
@@ -2,12 +2,14 @@ require "rails/generators"
 require "rails/generators/rails/model/model_generator"
 require "generators/scenic/view/view_generator"
 require "generators/scenic/materializable"
+require "generators/scenic/custom_pathable"
 
 module Scenic
   module Generators
     # @api private
     class ModelGenerator < Rails::Generators::NamedBase
       include Scenic::Generators::Materializable
+      include Scenic::Generators::CustomPathable
       source_root File.expand_path("../templates", __FILE__)
 
       def invoke_rails_model_generator

--- a/lib/generators/scenic/view/templates/db/migrate/create_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/create_view.erb
@@ -1,5 +1,5 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
-    create_view <%= formatted_plural_name %><%= ", materialized: true" if materialized? %>
+    create_view <%= formatted_plural_name %><%= ", materialized: true" if materialized? %><%= ", custom_path: '#{custom_path}'" if custom_path? %>
   end
 end

--- a/lib/generators/scenic/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/update_view.erb
@@ -1,12 +1,5 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
-  <%- if materialized? -%>
-    update_view <%= formatted_plural_name %>,
-      version: <%= version %>,
-      revert_to_version: <%= previous_version %>,
-      materialized: true
-  <%- else -%>
-    update_view <%= formatted_plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
-  <%- end -%>
+    update_view <%= formatted_plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %><%= ", materialized: true" if materialized? %><%= ", custom_path: '#{custom_path}'" if custom_path? %>
   end
 end

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -68,18 +68,18 @@ module Scenic
       private
 
       def views_directory_path
-        @views_directory_path ||= Rails.root.join(base_path, 'views')
+        @views_directory_path ||= Rails.root.join(base_path, "views")
       end
 
       def migration_directory_path
-        @migration_directory_path ||= Rails.root.join(base_path, 'migrate')
+        @migration_directory_path ||= Rails.root.join(base_path, "migrate")
       end
 
       def base_path
         @base_path ||= if custom_path.present?
                          custom_path
                        else
-                         'db'
+                         "db"
                        end
       end
 

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -1,6 +1,7 @@
 require "rails/generators"
 require "rails/generators/active_record"
 require "generators/scenic/materializable"
+require "generators/scenic/custom_pathable"
 
 module Scenic
   module Generators
@@ -8,6 +9,7 @@ module Scenic
     class ViewGenerator < Rails::Generators::NamedBase
       include Rails::Generators::Migration
       include Scenic::Generators::Materializable
+      include Scenic::Generators::CustomPathable
       source_root File.expand_path("../templates", __FILE__)
 
       def create_views_directory
@@ -28,12 +30,12 @@ module Scenic
         if creating_new_view? || destroying_initial_view?
           migration_template(
             "db/migrate/create_view.erb",
-            "db/migrate/create_#{plural_file_name}.rb",
+            "#{migration_directory_path}/create_#{plural_file_name}.rb",
           )
         else
           migration_template(
             "db/migrate/update_view.erb",
-            "db/migrate/update_#{plural_file_name}_to_version_#{version}.rb",
+            "#{migration_directory_path}/update_#{plural_file_name}_to_version_#{version}.rb",
           )
         end
       end
@@ -66,7 +68,19 @@ module Scenic
       private
 
       def views_directory_path
-        @views_directory_path ||= Rails.root.join(*%w(db views))
+        @views_directory_path ||= Rails.root.join(base_path, 'views')
+      end
+
+      def migration_directory_path
+        @migration_directory_path ||= Rails.root.join(base_path, 'migrate')
+      end
+
+      def base_path
+        @base_path ||= if custom_path.present?
+                         custom_path
+                       else
+                         'db'
+                       end
       end
 
       def version_regex
@@ -78,11 +92,11 @@ module Scenic
       end
 
       def definition
-        Scenic::Definition.new(plural_file_name, version)
+        Scenic::Definition.new(plural_file_name, version, custom_path)
       end
 
       def previous_definition
-        Scenic::Definition.new(plural_file_name, previous_version)
+        Scenic::Definition.new(plural_file_name, previous_version, custom_path)
       end
 
       def plural_file_name

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -21,9 +21,9 @@ module Scenic
 
     def path
       if @custom_path.blank?
-        File.join('db', 'views', filename)
+        File.join("db", "views", filename)
       else
-        File.join(@custom_path, 'views', filename)
+        File.join(@custom_path, "views", filename)
       end
     end
 

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -1,9 +1,10 @@
 module Scenic
   # @api private
   class Definition
-    def initialize(name, version)
+    def initialize(name, version, custom_path)
       @name = name
       @version = version.to_i
+      @custom_path = custom_path
     end
 
     def to_sql
@@ -19,7 +20,11 @@ module Scenic
     end
 
     def path
-      File.join("db", "views", filename)
+      if @custom_path.blank?
+        File.join('db', 'views', filename)
+      else
+        File.join(@custom_path, 'views', filename)
+      end
     end
 
     def version

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -21,7 +21,7 @@ module Scenic
     #     SELECT * FROM users WHERE users.active = 't'
     #   SQL
     #
-    def create_view(name, version: 1, sql_definition: nil, materialized: false)
+    def create_view(name, version: 1, sql_definition: nil, materialized: false, custom_path: nil)
       if version.blank? && sql_definition.nil?
         raise(
           ArgumentError,
@@ -29,7 +29,7 @@ module Scenic
         )
       end
 
-      sql_definition ||= definition(name, version)
+      sql_definition ||= definition(name, version, custom_path)
 
       if materialized
         Scenic.database.create_materialized_view(name, sql_definition)
@@ -51,7 +51,7 @@ module Scenic
     # @example Drop a view, rolling back to version 3 on rollback
     #   drop_view(:users_who_recently_logged_in, revert_to_version: 3)
     #
-    def drop_view(name, revert_to_version: nil, materialized: false)
+    def drop_view(name, revert_to_version: nil, materialized: false, custom_path: nil)
       if materialized
         Scenic.database.drop_materialized_view(name)
       else
@@ -75,12 +75,12 @@ module Scenic
     # @example
     #   update_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def update_view(name, version: nil, revert_to_version: nil, materialized: false)
+    def update_view(name, version: nil, revert_to_version: nil, materialized: false, custom_path: nil)
       if version.blank?
         raise ArgumentError, "version is required"
       end
 
-      sql_definition = definition(name, version)
+      sql_definition = definition(name, version, custom_path)
 
       if materialized
         Scenic.database.update_materialized_view(name, sql_definition)
@@ -105,7 +105,7 @@ module Scenic
     # @example
     #   replace_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def replace_view(name, version: nil, revert_to_version: nil, materialized: false)
+    def replace_view(name, version: nil, revert_to_version: nil, materialized: false, custom_path: nil)
       if version.blank?
         raise ArgumentError, "version is required"
       end
@@ -114,15 +114,15 @@ module Scenic
         raise ArgumentError, "Cannot replace materialized views"
       end
 
-      sql_definition = definition(name, version)
+      sql_definition = definition(name, version, custom_path)
 
       Scenic.database.replace_view(name, sql_definition)
     end
 
     private
 
-    def definition(name, version)
-      Scenic::Definition.new(name, version).to_sql
+    def definition(name, version, custom_path)
+      Scenic::Definition.new(name, version, custom_path).to_sql
     end
   end
 end

--- a/spec/scenic/definition_spec.rb
+++ b/spec/scenic/definition_spec.rb
@@ -7,7 +7,7 @@ module Scenic
         sql_definition = "SELECT text 'Hi' as greeting"
         allow(File).to receive(:read).and_return(sql_definition)
 
-        definition = Definition.new("searches", 1)
+        definition = Definition.new("searches", 1, nil)
 
         expect(definition.to_sql).to eq sql_definition
       end
@@ -16,24 +16,36 @@ module Scenic
         allow(File).to receive(:read).and_return("")
 
         expect do
-          Definition.new("searches", 1).to_sql
+          Definition.new("searches", 1, nil).to_sql
         end.to raise_error RuntimeError
       end
     end
 
     describe "path" do
-      it "returns a sql file in db/views with padded version and view name"  do
-        expected = "db/views/searches_v01.sql"
+      context "no custom path" do
+        it "returns a sql file in db/views with padded version and view name"  do
+          expected = "db/views/searches_v01.sql"
 
-        definition = Definition.new("searches", 1)
+          definition = Definition.new("searches", 1, nil)
 
-        expect(definition.path).to eq expected
+          expect(definition.path).to eq expected
+        end
+      end
+
+      context "with custom path" do
+        it "returns a sql file in custom path with padded version and view name"  do
+          expected = "my_path/views/searches_v01.sql"
+
+          definition = Definition.new("searches", 1, "my_path")
+
+          expect(definition.path).to eq expected
+        end
       end
     end
 
     describe "full_path" do
       it "joins the path with Rails.root" do
-        definition = Definition.new("searches", 15)
+        definition = Definition.new("searches", 15, nil)
 
         expect(definition.full_path).to eq Rails.root.join(definition.path)
       end
@@ -41,13 +53,13 @@ module Scenic
 
     describe "version" do
       it "pads the version number with 0" do
-        definition = Definition.new(:_, 1)
+        definition = Definition.new(:_, 1, nil)
 
         expect(definition.version).to eq "01"
       end
 
       it "doesn't pad more than 2 characters" do
-        definition = Definition.new(:_, 15)
+        definition = Definition.new(:_, 15, nil)
 
         expect(definition.version).to eq "15"
       end

--- a/spec/scenic/definition_spec.rb
+++ b/spec/scenic/definition_spec.rb
@@ -23,7 +23,7 @@ module Scenic
 
     describe "path" do
       context "no custom path" do
-        it "returns a sql file in db/views with padded version and view name"  do
+        it "returns a sql file in db/views with padded version and view name" do
           expected = "db/views/searches_v01.sql"
 
           definition = Definition.new("searches", 1, nil)
@@ -33,7 +33,7 @@ module Scenic
       end
 
       context "with custom path" do
-        it "returns a sql file in custom path with padded version and view name"  do
+        it "returns a sql file in custom path with padded version and view name" do
           expected = "my_path/views/searches_v01.sql"
 
           definition = Definition.new("searches", 1, "my_path")

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -10,9 +10,10 @@ module Scenic
     describe "create_view" do
       it "creates a view from a file" do
         version = 15
+        custom_path = nil
         definition_stub = instance_double("Definition", to_sql: "foo")
         allow(Definition).to receive(:new)
-          .with(:views, version)
+          .with(:views, version, custom_path)
           .and_return(definition_stub)
 
         connection.create_view :views, version: version
@@ -68,7 +69,7 @@ module Scenic
       it "updates the view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-          .with(:name, 3)
+          .with(:name, 3, nil)
           .and_return(definition)
 
         connection.update_view(:name, version: 3)
@@ -80,7 +81,7 @@ module Scenic
       it "updates the materialized view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-          .with(:name, 3)
+          .with(:name, 3, nil)
           .and_return(definition)
 
         connection.update_view(:name, version: 3, materialized: true)
@@ -99,7 +100,7 @@ module Scenic
       it "replaces the view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-          .with(:name, 3)
+          .with(:name, 3, nil)
           .and_return(definition)
 
         connection.replace_view(:name, version: 3)
@@ -111,7 +112,7 @@ module Scenic
       it "fails to replace the materialized view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
-          .with(:name, 3)
+          .with(:name, 3, nil)
           .and_return(definition)
 
         expect do

--- a/spec/support/view_definition_helpers.rb
+++ b/spec/support/view_definition_helpers.rb
@@ -1,6 +1,6 @@
 module ViewDefinitionHelpers
   def with_view_definition(name, version, schema)
-    definition = Scenic::Definition.new(name, version)
+    definition = Scenic::Definition.new(name, version, nil)
     FileUtils.mkdir_p(File.dirname(definition.full_path))
     File.open(definition.full_path, "w") { |f| f.write(schema) }
     yield


### PR DESCRIPTION
In a project I have a number of different databases setup, each database has it's own folder and I have a rake task which sets runs through the different databases and runs the migrations for them. The structure looks like below;

```
# apps main db
- db
  - schema.rb
  - migrate
    - 123_migration_1.rb
    - 456_migration_2.rb
# other database
- db_foobar
  - schema.rb
  - migrate
    - 098_migration_1.rb
    - 765_migration_2.rb
```
I have the need to create a view inside the other database and for this the migrations and the views need to go into the `db_foobar` folder. I can drag them into the correct folder once we create them, however as scenic hardcodes the definition path to `db/migrate` this fails.

This PR adds the ability to either manually add `custom_path` to the scenic migrations (`create_view`. `update_view` etc.) or pass this in as an option to the generator (`rails g scenic:view my_view --custom_path=db_foobar`)

This will not effect the default use of scenic at all.

Let me know your thoughts on if this would be of interest and if any changes are needed.