### PR TITLE
Don't lock materialized views when updating them

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ a new version of it.
 This is not desirable when you have complicated hierarchies of views, especially
 when some of those views may be materialized and take a long time to recreate.
 
-You can use `replace_view` to generate a CREATE OR REPLACE VIEW SQL statement.
+You can use `replace_view`. `replace_view` generates a CREATE OR REPLACE VIEW
+SQL statement on a normal view. For a materialized view, it creates a new
+materialized view under a temporary name (including the index definition
+specified in that version of the materialized view), then it drops the previous
+existing materialized view and then renames the new materialized view to its
+original name.
 
 See postgresql documentation on how this works:
 http://www.postgresql.org/docs/current/static/sql-createview.html

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -154,23 +154,48 @@ module Scenic
       def update_materialized_view(name, sql_definition)
         raise_unless_materialized_views_supported
 
-        temp_mv_name = "#{name}_temp"
         IndexReapplication.new(connection: connection).on(name) do
-          mv_definition = get_definition_for(:create_definition, sql_definition)
-          create_materialized_view(temp_mv_name, mv_definition.first)
-
-          new_index_definitions = get_definition_for(:indexes, sql_definition)
-
-          new_index_definitions.each do |idx_definition|
-            execute idx_definition.gsub(name, temp_mv_name)
-          end
-
-          drop_materialized_view(name)
-
-          execute "ALTER MATERIALIZED VIEW #{quote_table_name(temp_mv_name)} RENAME TO #{quote_table_name(name)};"
-
-          update_index_names_for(temp_mv_name, name)
+          replace_materialized_view(name, sql_definition)
         end
+      end
+
+      # Replaces a materialized view in the database.
+      #
+      # Recreate the materialized view under a temporary name and apply new
+      # indexes (if any). Drop previous materialized view, renames the
+      # temporary materialized view to its original name.
+      #
+      # This is typically called in a migration via {Statements#replace_view}.
+      #
+      # @param name The name of the view to update
+      # @param sql_definition The SQL schema for the updated view.
+      #
+      # @raise [MaterializedViewsNotSupportedError] if the version of Postgres
+      #   in use does not support materialized views.
+      #
+      # @return [void]
+      def replace_materialized_view(name, sql_definition)
+        raise_unless_materialized_views_supported
+
+        temp_mv_name = "#{name}_temp"
+
+        mv_definition = get_definition_for(:create_definition, sql_definition)
+        create_materialized_view(temp_mv_name, mv_definition.first)
+
+        new_index_definitions = get_definition_for(:indexes, sql_definition)
+
+        new_index_definitions.each do |idx_definition|
+          execute idx_definition.gsub(name, temp_mv_name)
+        end
+
+        drop_materialized_view(name)
+
+        sql = "ALTER MATERIALIZED VIEW #{quote_table_name(temp_mv_name)} " +
+          "RENAME TO #{quote_table_name(name)};"
+
+        execute sql
+
+        update_index_names_for(temp_mv_name, name)
       end
 
       # Drops a materialized view in the database
@@ -260,7 +285,9 @@ module Scenic
         indexes_for(tbl).map { |r| r["indexname"] }.each do |indexname|
           new_indexname = indexname.gsub(old_tbl, tbl)
 
-          execute "ALTER INDEX #{indexname} RENAME TO #{new_indexname}" unless indexname == new_indexname
+          if indexname != new_indexname
+            execute "ALTER INDEX #{indexname} RENAME TO #{new_indexname}"
+          end
         end
       end
 
@@ -277,6 +304,7 @@ module Scenic
           send(command) do |sql_line|
             sql_line.
               gsub(/\n/, "").
+              upcase.
               start_with?("CREATE INDEX", "CREATE UNIQUE INDEX")
           end
       end

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -257,7 +257,7 @@ module Scenic
       end
 
       def update_index_names_for(old_tbl, tbl)
-        indexes_for(tbl).map{ |r| r['indexname'] }.each do |indexname|
+        indexes_for(tbl).map { |r| r["indexname"] }.each do |indexname|
           new_indexname = indexname.gsub(old_tbl, tbl)
 
           execute "ALTER INDEX #{indexname} RENAME TO #{new_indexname}" unless indexname == new_indexname
@@ -273,11 +273,11 @@ module Scenic
 
         sql_definition.
           strip.
-          split(';').
+          split(";").
           send(command) do |sql_line|
             sql_line.
-              gsub(/\n/,'').
-              start_with?('CREATE INDEX', 'CREATE UNIQUE INDEX')
+              gsub(/\n/, "").
+              start_with?("CREATE INDEX", "CREATE UNIQUE INDEX")
           end
       end
     end

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -111,7 +111,6 @@ module Scenic
     # The existing view is replaced using the supplied `version`
     # parameter.
     #
-    # Does not work with materialized views due to lack of database support.
     #
     # @param name [String, Symbol] The name of the database view.
     # @param version [Fixnum] The version number of the view.
@@ -127,13 +126,13 @@ module Scenic
         raise ArgumentError, "version is required"
       end
 
-      if materialized
-        raise ArgumentError, "Cannot replace materialized views"
-      end
-
       sql_definition = definition(name, version)
 
-      Scenic.database.replace_view(name, sql_definition)
+      if materialized
+        Scenic.database.replace_materialized_view(name, sql_definition)
+      else
+        Scenic.database.replace_view(name, sql_definition)
+      end
     end
 
     private

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -140,15 +140,16 @@ module Scenic
           .with(:name, definition.to_sql)
       end
 
-      it "fails to replace the materialized view in the database" do
+      it "replaces the materialized view in the database" do
         definition = instance_double("Definition", to_sql: "definition")
         allow(Definition).to receive(:new)
           .with(:name, 3)
           .and_return(definition)
 
-        expect do
-          connection.replace_view(:name, version: 3, materialized: true)
-        end.to raise_error(ArgumentError, /Cannot replace materialized views/)
+        connection.replace_view(:name, version: 3, materialized: true)
+
+        expect(Scenic.database).to have_received(:replace_materialized_view).
+          with(:name, definition.to_sql)
       end
 
       it "raises an error if not supplied a version" do


### PR DESCRIPTION
Update to /lib/scenic/adapters/postgres.rb#update_materialized_view

**Before if there were big changes done to a materialized view, when that migration was run on a production environment, it would lock up the materialized view and it would result in end users having a bad experience. This PR addresses this issue by doing the following:**

When updating a materialized view, instead of:
- Dropping the materialized view
- Recreating the materialized view from the latest version

Do the following:
- Create a materialized view from the latest version with a temporary name ("#{materialized_view_name}_temp").
   This includes applying the new indexes contained in the new version.
- Drop the old materialized view
- Rename the newly created temporary view to the original name

I saw that there weren't any specs for `#update_materialized_view` so I did not write any, also this would be hard to test. All existing specs passed locally (`bin/appraisal rake`). You can verify that this works by having a v1 of a view, then on the v2 of it make it really complex (completely different SELECT, indexes) so it takes a good amount of time to run that migration, while the migration is running, connect to the database and query the materialized view and verify that its not locked and you can get results from it (previous version).
