### PR TITLE
Support for unusual characters on a view's name

### DIFF
--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -43,9 +43,9 @@ module Scenic
           namespace, viewname = result.values_at "namespace", "viewname"
 
           if namespace != "public"
-            namespaced_viewname = "#{namespace}.#{viewname}"
+            namespaced_viewname = "#{pg_identifier(namespace)}.#{pg_identifier(viewname)}"
           else
-            namespaced_viewname = viewname
+            namespaced_viewname = pg_identifier(viewname)
           end
 
           Scenic::View.new(
@@ -53,6 +53,13 @@ module Scenic
             definition: result["definition"].strip,
             materialized: result["kind"] == "m",
           )
+        end
+
+        private
+
+        def pg_identifier(name)
+          return name if name =~ /^[a-zA-Z_][a-zA-Z0-9_]*$/
+          PGconn.quote_ident(name) 
         end
       end
     end

--- a/lib/scenic/adapters/postgres/views.rb
+++ b/lib/scenic/adapters/postgres/views.rb
@@ -55,11 +55,9 @@ module Scenic
           )
         end
 
-        private
-
         def pg_identifier(name)
           return name if name =~ /^[a-zA-Z_][a-zA-Z0-9_]*$/
-          PGconn.quote_ident(name) 
+          PGconn.quote_ident(name)
         end
       end
     end

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -43,10 +43,9 @@ module Scenic
     # @api private
     def to_schema
       materialized_option = materialized ? "materialized: true, " : ""
-      safe_to_symbolize_name = name.include?(".") ? "'#{name}'" : name
 
       <<-DEFINITION
-  create_view :#{safe_to_symbolize_name}, #{materialized_option} sql_definition: <<-\SQL
+  create_view #{name.inspect}, #{materialized_option} sql_definition: <<-\SQL
     #{definition.indent(2)}
   SQL
 

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 class Search < ActiveRecord::Base; end
+class SearchInAHaystack < ActiveRecord::Base; self.table_name = '"search in a haystack"'; end
 
 describe Scenic::SchemaDumper, :db do
   it "dumps a create_view for a view in the database" do
@@ -11,7 +12,7 @@ describe Scenic::SchemaDumper, :db do
     ActiveRecord::SchemaDumper.dump(Search.connection, stream)
 
     output = stream.string
-    expect(output).to include "create_view :searches"
+    expect(output).to include 'create_view "searches"'
     expect(output).to include view_definition
 
     Search.connection.drop_view :searches
@@ -31,9 +32,50 @@ describe Scenic::SchemaDumper, :db do
       ActiveRecord::SchemaDumper.dump(Search.connection, stream)
 
       output = stream.string
-      expect(output).to include "create_view :'scenic.searches',"
+      expect(output).to include 'create_view "scenic.searches",'
 
       Search.connection.drop_view :'scenic.searches'
+    end
+  end
+
+  context "with views using unexpected characters in name" do
+    it "dumps a create_view for a view in the database" do
+      view_definition = "SELECT 'needle'::text AS haystack"
+      Search.connection.create_view '"search in a haystack"', sql_definition: view_definition
+      stream = StringIO.new
+
+      ActiveRecord::SchemaDumper.dump(Search.connection, stream)
+
+      output = stream.string
+      expect(output).to include 'create_view "\"search in a haystack\"",'
+      expect(output).to include view_definition
+
+      Search.connection.drop_view :'"search in a haystack"'
+
+      silence_stream(STDOUT) { eval(output) }
+
+      expect(SearchInAHaystack.take.haystack).to eq "needle"
+    end
+  end
+
+  context "with views using unexpected characters in name including namespace" do
+    it "dumps a create_view for a view in the database" do
+      view_definition = "SELECT 'needle'::text AS haystack"
+      Search.connection.execute "CREATE SCHEMA scenic; SET search_path TO scenic, public"
+      Search.connection.create_view 'scenic."search in a haystack"', sql_definition: view_definition
+      stream = StringIO.new
+
+      ActiveRecord::SchemaDumper.dump(Search.connection, stream)
+
+      output = stream.string
+      expect(output).to include 'create_view "scenic.\"search in a haystack\"",'
+      expect(output).to include view_definition
+
+      Search.connection.drop_view :'scenic."search in a haystack"'
+
+      silence_stream(STDOUT) { eval(output) }
+
+      expect(SearchInAHaystack.take.haystack).to eq "needle"
     end
   end
 end

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -1,7 +1,10 @@
 require "spec_helper"
 
 class Search < ActiveRecord::Base; end
-class SearchInAHaystack < ActiveRecord::Base; self.table_name = '"search in a haystack"'; end
+
+class SearchInAHaystack < ActiveRecord::Base
+   self.table_name = '"search in a haystack"'
+end
 
 describe Scenic::SchemaDumper, :db do
   it "dumps a create_view for a view in the database" do
@@ -58,11 +61,13 @@ describe Scenic::SchemaDumper, :db do
     end
   end
 
-  context "with views using unexpected characters in name including namespace" do
+  context "with views using unexpected characters, name including namespace" do
     it "dumps a create_view for a view in the database" do
       view_definition = "SELECT 'needle'::text AS haystack"
-      Search.connection.execute "CREATE SCHEMA scenic; SET search_path TO scenic, public"
-      Search.connection.create_view 'scenic."search in a haystack"', sql_definition: view_definition
+      Search.connection.execute(
+        "CREATE SCHEMA scenic; SET search_path TO scenic, public")
+      Search.connection.create_view 'scenic."search in a haystack"', 
+          sql_definition: view_definition
       stream = StringIO.new
 
       ActiveRecord::SchemaDumper.dump(Search.connection, stream)


### PR DESCRIPTION
I have to support latin1 characters on some view's name, so I made a few fixes so that I could still use scenic.