### PR TITLE
Update rails50 Appraisals to use Rails 5 proper

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -15,12 +15,7 @@ end
 
 if RUBY_VERSION > "2.2.0"
   appraise "rails50" do
-    gem "rails", github: "rails/rails"
-    gem "rspec-rails", github: "rspec/rspec-rails"
-    gem "rspec-support", github: "rspec/rspec-support"
-    gem "rspec-core", github: "rspec/rspec-core"
-    gem "rspec-mocks", github: "rspec/rspec-mocks"
-    gem "rspec-expectations", github: "rspec/rspec-expectations"
-    gem "rspec", github: "rspec/rspec"
+    gem "activerecord", "~> 5.0"
+    gem "railties", "~> 5.0"
   end
 end

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -2,12 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", :github => "rails/rails"
-gem "rspec-rails", :github => "rspec/rspec-rails"
-gem "rspec-support", :github => "rspec/rspec-support"
-gem "rspec-core", :github => "rspec/rspec-core"
-gem "rspec-mocks", :github => "rspec/rspec-mocks"
-gem "rspec-expectations", :github => "rspec/rspec-expectations"
-gem "rspec", :github => "rspec/rspec"
+gem "activerecord", "~> 5.0"
+gem "railties", "~> 5.0"
 
 gemspec :path => "../"


### PR DESCRIPTION
With the release of Rails 5, there is no need to fetch Rails from its
master branch to install it.