### PR TITLE
Generate migrations warning free on Rails 5

### DIFF
--- a/lib/generators/scenic/view/templates/db/migrate/create_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/create_view.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
     create_view <%= formatted_plural_name %><%= ", materialized: true" if materialized? %>
   end

--- a/lib/generators/scenic/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/update_view.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
   <%- if materialized? -%>
     update_view <%= formatted_plural_name %>,

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -61,6 +61,14 @@ module Scenic
             "Update#{class_name.pluralize}ToVersion#{version}"
           end
         end
+
+        def activerecord_migration_class
+          if ActiveRecord::Migration.respond_to?(:current_version)
+            "ActiveRecord::Migration[5.0]"
+          else
+            "ActiveRecord::Migration"
+          end
+        end
       end
 
       private


### PR DESCRIPTION
Rails 5 introduced versioned migrations to cope with breaking changes in
the migrations API. To remedy those breakages, versioned migrations were
introduced.

The new migration syntax is only generated on Rails 5.0 and above.

References #176