### PR TITLE
Update bin/setup and acceptance_helper.rb

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -10,3 +10,10 @@ if [ -z "$CI" ]; then
 fi
 
 bundle exec rake dummy:db:create
+
+if ! [ -z "$CI" ]; then
+  rails -v | grep -q '5.'
+  if [[ $? -eq 0 ]]; then
+    bundle exec rake dummy:db:environment:set RAILS_ENV=test
+  fi
+fi

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -21,12 +21,21 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     Dir.chdir("spec/dummy") do
-      system <<-CMD
-        rake db:drop db:create &&
-        git add -A &&
-        git reset --hard HEAD 1>/dev/null &&
-        rm -rf .git/ 1>/dev/null
-      CMD
+      if Rails::VERSION::MAJOR >= 5
+        system <<-CMD
+          rake db:drop db:create db:environment:set &&
+          git add -A &&
+          git reset --hard HEAD 1>/dev/null &&
+          rm -rf .git/ 1>/dev/null
+        CMD
+      else
+        system <<-CMD
+          rake db:drop db:create &&
+          git add -A &&
+          git reset --hard HEAD 1>/dev/null &&
+          rm -rf .git/ 1>/dev/null
+        CMD
+      end
     end
   end
 end


### PR DESCRIPTION
Some folks were encoutering issues with the additional security layer for
databases that came in Rails 5, which was preventing the dropping of the test
database. This commit adds in some conditional stuff to do that additional
setup for Rails 5.

@derekprior - for some reason I wasn't able to see this fail on my machine, but
I'm curious if it does the job for you. I was able to do the five things you
listed in the issue without problem, so hopefully it'll work!

Resolves #177