### PR TITLE
Fix test suite issues

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -21,11 +21,6 @@ if RUBY_VERSION > "2.2.0"
 
   appraise "rails-edge" do
     gem "rails", github: "rails/rails"
-    gem "rspec-rails", github: "rspec/rspec-rails"
-    gem "rspec-support", github: "rspec/rspec-support"
-    gem "rspec-core", github: "rspec/rspec-core"
-    gem "rspec-mocks", github: "rspec/rspec-mocks"
-    gem "rspec-expectations", github: "rspec/rspec-expectations"
-    gem "rspec", github: "rspec/rspec"
+    gem "arel", github: "rails/arel"
   end
 end

--- a/bin/setup
+++ b/bin/setup
@@ -9,4 +9,5 @@ if [ -z "$CI" ]; then
   bundle exec appraisal install
 fi
 
+bundle exec rake dummy:db:drop
 bundle exec rake dummy:db:create

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -3,11 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", :github => "rails/rails"
-gem "rspec-rails", :github => "rspec/rspec-rails"
-gem "rspec-support", :github => "rspec/rspec-support"
-gem "rspec-core", :github => "rspec/rspec-core"
-gem "rspec-mocks", :github => "rspec/rspec-mocks"
-gem "rspec-expectations", :github => "rspec/rspec-expectations"
-gem "rspec", :github => "rspec/rspec"
+gem "arel", :github => "rails/arel"
 
 gemspec :path => "../"

--- a/spec/acceptance/user_manages_views_spec.rb
+++ b/spec/acceptance/user_manages_views_spec.rb
@@ -51,6 +51,7 @@ describe "User manages views" do
 
   it "handles plural view names gracefully during generation" do
     successfully "rails generate scenic:model search_results --materialized"
+    successfully "rails destroy scenic:model search_results --materialized"
   end
 
   def successfully(command)

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -22,7 +22,8 @@ RSpec.configure do |config|
   config.after(:suite) do
     Dir.chdir("spec/dummy") do
       system <<-CMD
-        rake db:drop db:create &&
+        echo &&
+        rake db:environment:set db:drop db:create &&
         git add -A &&
         git reset --hard HEAD 1>/dev/null &&
         rm -rf .git/ 1>/dev/null

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -4,3 +4,10 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+unless Rake::Task.task_defined?('db:environment:set')
+  desc 'dummy task for rails versions where this task does not exist'
+  task 'db:environment:set' do
+    #no op
+  end
+end


### PR DESCRIPTION
* Intermittent failures were caused because one acceptance spec was not
cleaning up after itself.
* Some developers were seeing test suite failures under Rails 5 because
`rake db:environment:set` needed to be run. This task doesn't exist in
earlier versions of Rails, so we created a dummy task in the dummy app
so we could call it nonetheless.
* Edge rails appraisal doesn't need edge rspec