### PR TITLE
Use HTTPS for GitHub gem sources

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -20,7 +20,7 @@ if RUBY_VERSION > "2.2.0"
   end
 
   appraise "rails-edge" do
-    gem "rails", github: "rails/rails"
-    gem "arel", github: "rails/arel"
+    gem "rails", git: "https://github.com/rails/rails"
+    gem "arel", git: "https://github.com/rails/arel"
   end
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", :github => "rails/rails"
-gem "arel", :github => "rails/arel"
+gem "rails", :git => "https://github.com/rails/rails"
+gem "arel", :git => "https://github.com/rails/arel"
 
 gemspec :path => "../"


### PR DESCRIPTION
It will be the default in bundler 2.0: https://github.com/bundler/bundler/blob/2-0-dev/lib/bundler/dsl.rb#L240-L256

But right now it's making insecure connections.

FYI: I had to do `cd spec/dummy/; rake db:create` manually (I know it's in the `bin/setup`)