### PR TITLE
Ignore Rails' internal tables for schema dump

### DIFF
--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -27,14 +27,10 @@ module Scenic
       end
     end
 
-    unless ActiveRecord::SchemaDumper.instance_methods(false).include?(:ignored?)
+    unless ActiveRecord::SchemaDumper.private_instance_methods(false).include?(:ignored?)
       # This method will be present in Rails 4.2.0 and can be removed then.
       def ignored?(table_name)
-        [
-          "ar_internal_metadata",
-          "schema_migrations",
-          ignore_tables,
-        ].flatten.any? do |ignored|
+        ["schema_migrations", ignore_tables].flatten.any? do |ignored|
           case ignored
           when String; remove_prefix_and_suffix(table_name) == ignored
           when Regexp; remove_prefix_and_suffix(table_name) =~ ignored

--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -30,7 +30,11 @@ module Scenic
     unless ActiveRecord::SchemaDumper.instance_methods(false).include?(:ignored?)
       # This method will be present in Rails 4.2.0 and can be removed then.
       def ignored?(table_name)
-        ["schema_migrations", ignore_tables].flatten.any? do |ignored|
+        [
+          "ar_internal_metadata",
+          "schema_migrations",
+          ignore_tables,
+        ].flatten.any? do |ignored|
           case ignored
           when String; remove_prefix_and_suffix(table_name) == ignored
           when Regexp; remove_prefix_and_suffix(table_name) =~ ignored

--- a/spec/scenic/schema_dumper_spec.rb
+++ b/spec/scenic/schema_dumper_spec.rb
@@ -36,4 +36,18 @@ describe Scenic::SchemaDumper, :db do
       Search.connection.drop_view :'scenic.searches'
     end
   end
+
+  it "ignores tables internal to Rails" do
+    view_definition = "SELECT 'needle'::text AS haystack"
+    Search.connection.create_view :searches, sql_definition: view_definition
+    stream = StringIO.new
+
+    ActiveRecord::SchemaDumper.dump(Search.connection, stream)
+
+    output = stream.string
+
+    expect(output).to include "create_view :searches"
+    expect(output).not_to include "ar_internal_metadata"
+    expect(output).not_to include "schema_migrations"
+  end
 end


### PR DESCRIPTION
These tables are ignored by Rails itself, and Scenic should do so too.