### PR TITLE
Travis: Extend matrix with Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ notifications:
     - false
 sudo: false
 rvm:
-  - 2.3.0
-  - 2.2.4
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
   - 2.1.8
 gemfile:
   - gemfiles/rails40.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ gemfile:
   - gemfiles/rails_edge.gemfile
 matrix:
   exclude:
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails41.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/rails50.gemfile
     - gemfile: gemfiles/rails_edge.gemfile


### PR DESCRIPTION
This PR updates the CI matrix adding a Ruby 2.4

It also updates the version of the Rubies already in place to the same versions in use at Rails.