### PR TITLE
Add Rails 5.1 and edge Rails to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ gemfile:
   - gemfiles/rails40.gemfile
   - gemfiles/rails41.gemfile
   - gemfiles/rails42.gemfile
-  - gemfiles/rails42_with_fg_rails.gemfile
   - gemfiles/rails50.gemfile
+  - gemfiles/rails51.gemfile
   - gemfiles/rails_edge.gemfile
 matrix:
   exclude:
@@ -36,4 +36,9 @@ matrix:
       gemfile: gemfiles/rails41.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/rails50.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails51.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rails_edge.gemfile
+  allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,13 @@
-appraise "rails40" do
-  gem "activerecord", "~> 4.0.0"
-  gem "railties", "~> 4.0.0"
-end
+if RUBY_VERSION < "2.4.0"
+  appraise "rails40" do
+    gem "activerecord", "~> 4.0.0"
+    gem "railties", "~> 4.0.0"
+  end
 
-appraise "rails41" do
-  gem "activerecord", "~> 4.1.0"
-  gem "railties", "~> 4.1.0"
+  appraise "rails41" do
+    gem "activerecord", "~> 4.1.0"
+    gem "railties", "~> 4.1.0"
+  end
 end
 
 appraise "rails42" do
@@ -13,17 +15,15 @@ appraise "rails42" do
   gem "railties", "~> 4.2.0"
 end
 
-appraise "rails42-with-fg-rails" do
-  gem "activerecord", "~> 4.2.0"
-  gem "railties", "~> 4.2.0"
-  gem "rspec-rails"
-  gem "factory_girl_rails"
-end
-
 if RUBY_VERSION > "2.2.0"
   appraise "rails50" do
-    gem "activerecord", "~> 5.0"
-    gem "railties", "~> 5.0"
+    gem "activerecord", "~> 5.0.0"
+    gem "railties", "~> 5.0.0"
+  end
+
+  appraise "rails51" do
+    gem "activerecord", "~> 5.1.0"
+    gem "railties", "~> 5.1.0"
   end
 
   appraise "rails-edge" do

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0.0"
-gem "railties", "~> 5.0.0"
+gem "activerecord", "~> 5.1.0"
+gem "railties", "~> 5.1.0"
 
 gemspec :path => "../"

--- a/spec/generators/scenic/model/model_generator_spec.rb
+++ b/spec/generators/scenic/model/model_generator_spec.rb
@@ -32,12 +32,5 @@ module Scenic::Generators
       expect(model_definition).to contain("self.refresh")
       expect(model_definition).to have_correct_syntax
     end
-
-    it "does not create a factory definition" do
-      run_generator ["current_customer"]
-      factory_definition = file("spec/factories/current_customers.rb")
-
-      expect(factory_definition).not_to exist
-    end
   end
 end


### PR DESCRIPTION
We previously had an entry for edge rails but it was configured
incorrectly in the travis matrix. It was listed as an exclude rather
than an allowed failure.

This also removes the dedicated appraisal added for a single factory
girl related test and that test. I think the test was useful during
development, but not on an ongoing basis.