### PR TITLE
Use ActiveRecord::Migration.current_version instead of hardcoded value.

### DIFF
--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -64,7 +64,7 @@ module Scenic
 
         def activerecord_migration_class
           if ActiveRecord::Migration.respond_to?(:current_version)
-            "ActiveRecord::Migration[5.0]"
+            "ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]"
           else
             "ActiveRecord::Migration"
           end


### PR DESCRIPTION
If `ActiveRecord::Migration` responds to `current_version`, we should use that value instead of a hardcoded value. This pull request fixes that so that the generator is more future proof.