### PR TITLE
Fix adapter config example to use correct method on config

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -33,7 +33,7 @@ module Scenic
       #
       # @example
       #  Scenic.configure do |config|
-      #    config.adapter = Scenic::Adapters::Postgres.new
+      #    config.database = Scenic::Adapters::Postgres.new
       #  end
       def initialize(connectable = ActiveRecord::Base)
         @connectable = connectable


### PR DESCRIPTION
The correct method name is `database`, not `adapter`.