### PR TITLE
Schema Dumper :: Sort Views by Name

### DIFF
--- a/lib/scenic/schema_dumper.rb
+++ b/lib/scenic/schema_dumper.rb
@@ -22,7 +22,7 @@ module Scenic
     private
 
     def dumpable_views_in_database
-      @dumpable_views_in_database ||= Scenic.database.views.reject do |view|
+      @dumpable_views_in_database ||= Scenic.database.views.sort_by(&:name).reject do |view|
         ignored?(view.name)
       end
     end


### PR DESCRIPTION
- updated schema dumper to sort view definitions by name so that schema generation is deterministic

We ran into an issue where running migrations in rails would cause large diffs to be generated as view definitions would shuffle around in the schema dump because different dev machines have different values of `pg_class.oid`, which Scenic::Adapters::Postgres::Views::#views_from_postgres orders by in its query.

This patch should make the dump process deterministic.