### PR TITLE
Generate proper migration class name for non-public schemas

### DIFF
--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -56,7 +56,7 @@ module Scenic
 
         def migration_class_name
           if creating_new_view?
-            "Create#{class_name.gsub('.', '').pluralize}"
+            "Create#{cleaned_class_name}"
           else
             "Update#{class_name.pluralize}ToVersion#{version}"
           end
@@ -83,6 +83,10 @@ module Scenic
 
       def creating_new_view?
         previous_version == 0
+      end
+
+      def cleaned_class_name
+        class_name.gsub(/\../, &:upcase).delete(".").pluralize
       end
 
       def definition

--- a/spec/generators/scenic/view/view_generator_spec.rb
+++ b/spec/generators/scenic/view/view_generator_spec.rb
@@ -46,6 +46,7 @@ describe Scenic::Generators::ViewGenerator, :generator do
 
       expect(migration).to be_a_migration
       expect(view_definition).to exist
+      expect(migration_file(migration)).to contain "NonPublicSearches"
     end
   end
 end


### PR DESCRIPTION
Previously, the code would take `"non_public.search"` and turn it into `NonPublicsearches` by calling `#camelize`, gsubbing out the period, and then calling `#pluralize`. This pull capitalizes letters after periods before gsubbing them out, so you end up with `NonPublicSearches` as expected.

Based on my understanding, this should fix #187, but I might be missing part of that issue because the person who opened it indicated they needed to rename the sql file, but I don't think that should be necessary based on how I see the code working.