### PR TITLE
Materialized Views - Add option "WITH NO DATA"

### DIFF
--- a/lib/generators/scenic/materializable.rb
+++ b/lib/generators/scenic/materializable.rb
@@ -10,21 +10,21 @@ module Scenic
           required: false,
           desc: "Makes the view materialized",
           default: false
-        class_option :materialized_no_data,
+        class_option :no_data,
           type: :boolean,
           required: false,
-          desc: "Makes the view materialized with NO DATA",
+          desc: "Adds WITH NO DATA when materialized view creates/updates",
           default: false
       end
 
       private
 
       def materialized?
-        options[:materialized] || options[:materialized_no_data]
+        options[:materialized]
       end
 
-      def materialized_no_data?
-        options[:materialized_no_data]
+      def no_data?
+        options[:no_data]
       end
     end
   end

--- a/lib/generators/scenic/materializable.rb
+++ b/lib/generators/scenic/materializable.rb
@@ -10,12 +10,21 @@ module Scenic
           required: false,
           desc: "Makes the view materialized",
           default: false
+        class_option :materialized_no_data,
+          type: :boolean,
+          required: false,
+          desc: "Makes the view materialized with NO DATA",
+          default: false
       end
 
       private
 
       def materialized?
-        options[:materialized]
+        options[:materialized] || options[:materialized_no_data]
+      end
+
+      def materialized_no_data?
+        options[:materialized_no_data]
       end
     end
   end

--- a/lib/generators/scenic/view/USAGE
+++ b/lib/generators/scenic/view/USAGE
@@ -6,7 +6,7 @@ Description:
   and a migration to replace the old version with the new.
 
   To create a materialized view, pass the '--materialized' option.
-  To create a materialized view with NO DATA, pass '--materialized-no-data' option.
+  To create a materialized view with NO DATA, pass '--no-data' option.
 
 Examples:
     rails generate scenic:view searches

--- a/lib/generators/scenic/view/USAGE
+++ b/lib/generators/scenic/view/USAGE
@@ -6,6 +6,7 @@ Description:
   and a migration to replace the old version with the new.
 
   To create a materialized view, pass the '--materialized' option.
+  To create a materialized view with NO DATA, pass '--materialized-no-data' option.
 
 Examples:
     rails generate scenic:view searches

--- a/lib/generators/scenic/view/templates/db/migrate/create_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/create_view.erb
@@ -1,5 +1,5 @@
 class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
-    create_view <%= formatted_plural_name %><%= ", materialized: true" if materialized? %>
+    create_view <%= formatted_plural_name %><%= create_view_options %>
   end
 end

--- a/lib/generators/scenic/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/update_view.erb
@@ -4,7 +4,7 @@ class <%= migration_class_name %> < <%= activerecord_migration_class %>
     update_view <%= formatted_plural_name %>,
       version: <%= version %>,
       revert_to_version: <%= previous_version %>,
-      materialized: true
+      materialized: true<%= ", materialized_no_data: true" if materialized_no_data? %>
   <%- else -%>
     update_view <%= formatted_plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
   <%- end -%>

--- a/lib/generators/scenic/view/templates/db/migrate/update_view.erb
+++ b/lib/generators/scenic/view/templates/db/migrate/update_view.erb
@@ -4,7 +4,7 @@ class <%= migration_class_name %> < <%= activerecord_migration_class %>
     update_view <%= formatted_plural_name %>,
       version: <%= version %>,
       revert_to_version: <%= previous_version %>,
-      materialized: true<%= ", materialized_no_data: true" if materialized_no_data? %>
+      materialized: <%= no_data? ? "{ no_data: true }" : true %>
   <%- else -%>
     update_view <%= formatted_plural_name %>, version: <%= version %>, revert_to_version: <%= previous_version %>
   <%- end -%>

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -109,6 +109,13 @@ module Scenic
         end
       end
 
+      def create_view_options
+        view_options = ""
+        view_options += ", materialized: true" if materialized?
+        view_options += ", materialized_no_data: true" if materialized_no_data?
+        view_options
+      end
+
       def destroying_initial_view?
         destroying? && version == 1
       end

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -110,10 +110,8 @@ module Scenic
       end
 
       def create_view_options
-        view_options = ""
-        view_options += ", materialized: true" if materialized?
-        view_options += ", no_data: true" if no_data?
-        view_options
+        return "" unless materialized?
+        ", materialized: #{no_data? ? '{ no_data: true }' : true}"
       end
 
       def destroying_initial_view?

--- a/lib/generators/scenic/view/view_generator.rb
+++ b/lib/generators/scenic/view/view_generator.rb
@@ -112,7 +112,7 @@ module Scenic
       def create_view_options
         view_options = ""
         view_options += ", materialized: true" if materialized?
-        view_options += ", materialized_no_data: true" if materialized_no_data?
+        view_options += ", no_data: true" if no_data?
         view_options
       end
 

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -131,10 +131,13 @@ module Scenic
       #   in use does not support materialized views.
       #
       # @return [void]
-      def create_materialized_view(name, sql_definition, no_data = false)
+      def create_materialized_view(name, sql_definition, no_data: false)
         raise_unless_materialized_views_supported
-        no_data_option = no_data ? "\nWITH NO DATA" : ""
-        execute "CREATE MATERIALIZED VIEW #{quote_table_name(name)} AS #{sql_definition}#{no_data_option};"
+        execute <<-SQL
+  CREATE MATERIALIZED VIEW #{quote_table_name(name)} AS
+  #{sql_definition}
+  #{'WITH NO DATA' if no_data};
+        SQL
       end
 
       # Updates a materialized view in the database.
@@ -154,12 +157,12 @@ module Scenic
       #   in use does not support materialized views.
       #
       # @return [void]
-      def update_materialized_view(name, sql_definition, no_data = false)
+      def update_materialized_view(name, sql_definition, no_data: false)
         raise_unless_materialized_views_supported
 
         IndexReapplication.new(connection: connection).on(name) do
           drop_materialized_view(name)
-          create_materialized_view(name, sql_definition, no_data)
+          create_materialized_view(name, sql_definition, no_data: no_data)
         end
       end
 

--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -122,6 +122,8 @@ module Scenic
       #
       # @param name The name of the materialized view to create
       # @param sql_definition The SQL schema that defines the materialized view.
+      # @param no_data [Boolean] Default: false. Set to true to create materialized view fast w/o
+      # feeding it with data. You will then need to `REFRESH MATERIALIZED VIEW`
       #
       # This is typically called in a migration via {Statements#create_view}.
       #
@@ -129,9 +131,10 @@ module Scenic
       #   in use does not support materialized views.
       #
       # @return [void]
-      def create_materialized_view(name, sql_definition)
+      def create_materialized_view(name, sql_definition, no_data = false)
         raise_unless_materialized_views_supported
-        execute "CREATE MATERIALIZED VIEW #{quote_table_name(name)} AS #{sql_definition};"
+        no_data_option = no_data ? "\nWITH NO DATA" : ""
+        execute "CREATE MATERIALIZED VIEW #{quote_table_name(name)} AS #{sql_definition}#{no_data_option};"
       end
 
       # Updates a materialized view in the database.
@@ -144,17 +147,19 @@ module Scenic
       #
       # @param name The name of the view to update
       # @param sql_definition The SQL schema for the updated view.
+      # @param no_data [Boolean] Default: false. Set to true to create materialized view fast w/o
+      # feeding it with data. You will then need to `REFRESH MATERIALIZED VIEW`
       #
       # @raise [MaterializedViewsNotSupportedError] if the version of Postgres
       #   in use does not support materialized views.
       #
       # @return [void]
-      def update_materialized_view(name, sql_definition)
+      def update_materialized_view(name, sql_definition, no_data = false)
         raise_unless_materialized_views_supported
 
         IndexReapplication.new(connection: connection).on(name) do
           drop_materialized_view(name)
-          create_materialized_view(name, sql_definition)
+          create_materialized_view(name, sql_definition, no_data)
         end
       end
 

--- a/lib/scenic/statements.rb
+++ b/lib/scenic/statements.rb
@@ -21,7 +21,7 @@ module Scenic
     #     SELECT * FROM users WHERE users.active = 't'
     #   SQL
     #
-    def create_view(name, version: nil, sql_definition: nil, materialized: false)
+    def create_view(name, version: nil, sql_definition: nil, materialized: false, materialized_no_data: false)
       if version.present? && sql_definition.present?
         raise(
           ArgumentError,
@@ -36,7 +36,7 @@ module Scenic
       sql_definition ||= definition(name, version)
 
       if materialized
-        Scenic.database.create_materialized_view(name, sql_definition)
+        Scenic.database.create_materialized_view(name, sql_definition, materialized_no_data)
       else
         Scenic.database.create_view(name, sql_definition)
       end
@@ -82,7 +82,7 @@ module Scenic
     # @example
     #   update_view :engagement_reports, version: 3, revert_to_version: 2
     #
-    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false)
+    def update_view(name, version: nil, sql_definition: nil, revert_to_version: nil, materialized: false, materialized_no_data: false)
       if version.blank? && sql_definition.blank?
         raise(
           ArgumentError,
@@ -100,7 +100,7 @@ module Scenic
       sql_definition ||= definition(name, version)
 
       if materialized
-        Scenic.database.update_materialized_view(name, sql_definition)
+        Scenic.database.update_materialized_view(name, sql_definition, materialized_no_data)
       else
         Scenic.database.update_view(name, sql_definition)
       end

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -22,15 +22,20 @@ module Scenic
     # @return [Boolean]
     attr_reader :materialized
 
+    # True if the view is materialized with NO DATA
+    # @return [Boolean]
+    attr_reader :materialized_no_data
+
     # Returns a new instance of View.
     #
     # @param name [String] The name of the view.
     # @param definition [String] The SQL for the query that defines the view.
     # @param materialized [String] `true` if the view is materialized.
-    def initialize(name:, definition:, materialized:)
+    def initialize(name:, definition:, materialized:, materialized_no_data: false)
       @name = name
       @definition = definition
       @materialized = materialized
+      @materialized_no_data = materialized_no_data
     end
 
     # @api private
@@ -42,13 +47,14 @@ module Scenic
 
     # @api private
     def to_schema
-      materialized_option = materialized ? "materialized: true, " : ""
+      materialized_option = materialized || materialized_no_data ? "materialized: true, " : ""
+      no_data_option = materialized_no_data ? ", no_data: true" : ""
 
       <<-DEFINITION
   create_view #{name.inspect}, #{materialized_option} sql_definition: <<-\SQL
     #{definition.indent(2)}
   SQL
-
+  #{no_data_option}
       DEFINITION
     end
   end

--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -24,18 +24,18 @@ module Scenic
 
     # True if the view is materialized with NO DATA
     # @return [Boolean]
-    attr_reader :materialized_no_data
+    attr_reader :no_data
 
     # Returns a new instance of View.
     #
     # @param name [String] The name of the view.
     # @param definition [String] The SQL for the query that defines the view.
     # @param materialized [String] `true` if the view is materialized.
-    def initialize(name:, definition:, materialized:, materialized_no_data: false)
+    def initialize(name:, definition:, materialized:, no_data: false)
       @name = name
       @definition = definition
       @materialized = materialized
-      @materialized_no_data = materialized_no_data
+      @no_data = no_data
     end
 
     # @api private
@@ -47,8 +47,8 @@ module Scenic
 
     # @api private
     def to_schema
-      materialized_option = materialized || materialized_no_data ? "materialized: true, " : ""
-      no_data_option = materialized_no_data ? ", no_data: true" : ""
+      materialized_option = materialized ? "materialized: true, " : ""
+      no_data_option = no_data ? ", no_data: true" : ""
 
       <<-DEFINITION
   create_view #{name.inspect}, #{materialized_option} sql_definition: <<-\SQL

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -61,6 +61,17 @@ module Scenic
       end
     end
 
+    describe "create_view :materialized with :materialized_no_data" do
+      it "sends the create_materialized_view message" do
+        allow(Definition).to receive(:new)
+          .and_return(instance_double("Scenic::Definition").as_null_object)
+
+        connection.create_view(:views, version: 1, materialized: true, materialized_no_data: true)
+
+        expect(Scenic.database).to have_received(:create_materialized_view)
+      end
+    end
+
     describe "drop_view" do
       it "removes a view from the database" do
         connection.drop_view :name
@@ -108,7 +119,19 @@ module Scenic
         connection.update_view(:name, version: 3, materialized: true)
 
         expect(Scenic.database).to have_received(:update_materialized_view).
-          with(:name, definition.to_sql)
+          with(:name, definition.to_sql, false)
+      end
+
+      it "updates the materialized view in the database with NO DATA" do
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new)
+          .with(:name, 3)
+          .and_return(definition)
+
+        connection.update_view(:name, version: 3, materialized: true, materialized_no_data: true)
+
+        expect(Scenic.database).to have_received(:update_materialized_view).
+          with(:name, definition.to_sql, true)
       end
 
       it "raises an error if not supplied a version or sql_defintion" do

--- a/spec/scenic/statements_spec.rb
+++ b/spec/scenic/statements_spec.rb
@@ -52,23 +52,25 @@ module Scenic
 
     describe "create_view :materialized" do
       it "sends the create_materialized_view message" do
-        allow(Definition).to receive(:new)
-          .and_return(instance_double("Scenic::Definition").as_null_object)
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new).and_return(definition)
 
         connection.create_view(:views, version: 1, materialized: true)
 
-        expect(Scenic.database).to have_received(:create_materialized_view)
+        expect(Scenic.database).to have_received(:create_materialized_view).
+          with(:views, definition.to_sql, no_data: false)
       end
     end
 
-    describe "create_view :materialized with :materialized_no_data" do
+    describe "create_view :materialized with :no_data" do
       it "sends the create_materialized_view message" do
-        allow(Definition).to receive(:new)
-          .and_return(instance_double("Scenic::Definition").as_null_object)
+        definition = instance_double("Definition", to_sql: "definition")
+        allow(Definition).to receive(:new).and_return(definition)
 
-        connection.create_view(:views, version: 1, materialized: true, materialized_no_data: true)
+        connection.create_view(:views, version: 1, materialized: { no_data: true })
 
-        expect(Scenic.database).to have_received(:create_materialized_view)
+        expect(Scenic.database).to have_received(:create_materialized_view).
+          with(:views, definition.to_sql, no_data: true)
       end
     end
 
@@ -119,19 +121,19 @@ module Scenic
         connection.update_view(:name, version: 3, materialized: true)
 
         expect(Scenic.database).to have_received(:update_materialized_view).
-          with(:name, definition.to_sql, false)
+          with(:name, definition.to_sql, no_data: false)
       end
 
       it "updates the materialized view in the database with NO DATA" do
         definition = instance_double("Definition", to_sql: "definition")
-        allow(Definition).to receive(:new)
-          .with(:name, 3)
-          .and_return(definition)
+        allow(Definition).to receive(:new).
+          with(:name, 3).
+          and_return(definition)
 
-        connection.update_view(:name, version: 3, materialized: true, materialized_no_data: true)
+        connection.update_view(:name, version: 3, materialized: { no_data: true })
 
         expect(Scenic.database).to have_received(:update_materialized_view).
-          with(:name, definition.to_sql, true)
+          with(:name, definition.to_sql, no_data: true)
       end
 
       it "raises an error if not supplied a version or sql_defintion" do


### PR DESCRIPTION
This is amazing gem. Thank you for building and maintaining it!

At least for me, it happens so,  that I need to run migrations faster. Some huge materialized views might be refreshed for XX minutes/hours.
I'd propose to add an option `WITH NO DATA` for materialized views, to be able to call refresh of it later in some background logic.

What do you think? Is it a good candidate to be added into core functionality of the gem?