### PR TITLE
Make #readonly? method public in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ no different than a table.
 class SearchResult < ActiveRecord::Base
   belongs_to :searchable, polymorphic: true
 
-  private
-
   # this isn't strictly necessary, but it will prevent
   # rails from calling save, which would fail anyway.
   def readonly?


### PR DESCRIPTION
According to `rails`, the `#readonly?` method should be public. https://github.com/rails/rails/blob/a05845e0a699e169c11962212200dc8e72934dff/activerecord/lib/active_record/core.rb#L483