### PR TITLE
Remove dot from the mysql adapter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ We are aware of the following existing adapter libraries for Scenic which may
 meet your needs:
 
 * [scenic_sqlite_adapter](https://github.com/pdebelak/scenic_sqlite_adapter)
-* [scenic-mysql_adapter](https://github.com/EmpaticoOrg/scenic-mysql_adapter.)
+* [scenic-mysql_adapter](https://github.com/EmpaticoOrg/scenic-mysql_adapter)
 
 ## About
 


### PR DESCRIPTION
There seems to be an additional dot(`.`) in the MySQL adapter link, which throws a page not found error, this commit removes that dot from the link.