### PR TITLE
Gracefully handle case where view has no dependencies

### DIFF
--- a/lib/scenic/adapters/postgres/refresh_dependencies.rb
+++ b/lib/scenic/adapters/postgres/refresh_dependencies.rb
@@ -49,6 +49,7 @@ module Scenic
             idx = sorted_arr.find_index do |dep|
               dep.include?(view_to_refresh.to_s)
             end
+            return [] if idx.nil?
             sorted_arr[0...idx]
           end
 

--- a/scenic.gemspec
+++ b/scenic.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.3'
-  spec.add_development_dependency 'pg'
+  spec.add_development_dependency 'pg', '~> 0.19'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'ammeter', '>= 1.1.3'
   spec.add_development_dependency 'yard'

--- a/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
+++ b/spec/scenic/adapters/postgres/refresh_dependencies_spec.rb
@@ -37,6 +37,19 @@ module Scenic
 
         described_class.call(:fourth, adapter, ActiveRecord::Base.connection)
       end
+
+      it "does not raise an error when a view has no materialized view dependencies" do
+        adapter = Postgres.new
+
+        adapter.create_materialized_view(
+          "first",
+          "SELECT text 'hi' AS greeting",
+        )
+
+        expect {
+          described_class.call(:first, adapter, ActiveRecord::Base.connection)
+        }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
We were previously assuming that anytime a user passed `cascade: true`
to `refresh_materialized_view`, that the view they were attempting to
refresh actually had dependencies. Turns out, we would end up with a
weird exception in this case.

I've changed it so the `cascade: true` part of that operation is
essentially a NOOP now, not raising any exception. I figured that it
would still accomplish what the user set out to do (refresh their
materialized view) without requiring any additional understanding or
changing of code.

Resolves #230 