### PR TITLE
Support multiple views paths

### DIFF
--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -15,12 +15,12 @@ module Scenic
     end
 
     def find_definition
-      definition = views_paths.expanded.flat_map do |directory|
+      definition = views_paths.flat_map do |directory|
         Dir.glob("#{directory}/**/#{filename}")
       end.first
 
       unless definition
-        raise "Unable to locate #{filename} in #{views_paths.expanded}"
+        raise "Unable to locate #{filename} in #{views_paths}"
       end
 
       definition
@@ -41,7 +41,7 @@ module Scenic
     private
 
     def views_paths
-      Rails.application.config.paths["db/views"]
+      Rails.application.config.paths["db/views"].expanded
     end
 
     def filename

--- a/lib/scenic/definition.rb
+++ b/lib/scenic/definition.rb
@@ -7,11 +7,23 @@ module Scenic
     end
 
     def to_sql
-      File.read(full_path).tap do |content|
+      File.read(find_definition).tap do |content|
         if content.empty?
           raise "Define view query in #{path} before migrating."
         end
       end
+    end
+
+    def find_definition
+      definition = views_paths.expanded.flat_map do |directory|
+        Dir.glob("#{directory}/**/#{filename}")
+      end.first
+
+      unless definition
+        raise "Unable to locate #{filename} in #{views_paths.expanded}"
+      end
+
+      definition
     end
 
     def full_path
@@ -27,6 +39,10 @@ module Scenic
     end
 
     private
+
+    def views_paths
+      Rails.application.config.paths["db/views"]
+    end
 
     def filename
       "#{@name}_v#{version}.sql"

--- a/lib/scenic/railtie.rb
+++ b/lib/scenic/railtie.rb
@@ -7,6 +7,8 @@ module Scenic
   # @see Scenic.load
   class Railtie < Rails::Railtie
     initializer "scenic.load" do
+      Rails.application.config.paths.add("db/views")
+
       ActiveSupport.on_load :active_record do
         Scenic.load
       end

--- a/spec/fixtures/db_views/searches_v01.sql
+++ b/spec/fixtures/db_views/searches_v01.sql
@@ -1,0 +1,1 @@
+SELECT text 'Hi' as greeting


### PR DESCRIPTION
I needed to use this in a rails engine and didn't want to have to copy db_views over for every rails app. 

This makes it so the the definition is searched for in multiple paths when trying to call `to_sql`. Generator paths aren't affected. I leveraged Rails' `config.paths` for configuring additional `db/views` paths. I could change it so that the paths are apart of `Scenic::Configuration`, I just thought putting it in `Rails.config.paths['db/views']` would pair nicely with `Rails.config.paths['db/migrations']` works.

I'm able to make this work with a rails engine by using the following in `engine.rb`

```ruby
    initializer :append_migrations do |app|
      app.config.paths["db/views"] << root.join("db/views")

      unless app.root.to_s.match? root.to_s
        config.paths["db/migrate"].expanded.each do |expanded_path|
          app.config.paths["db/migrate"] << expanded_path
        end
      end
    end
```

 