### PR TITLE
Remove extra space from schema dumper output

### DIFF
--- a/lib/scenic/view.rb
+++ b/lib/scenic/view.rb
@@ -45,7 +45,7 @@ module Scenic
       materialized_option = materialized ? "materialized: true, " : ""
 
       <<-DEFINITION
-  create_view #{name.inspect}, #{materialized_option} sql_definition: <<-\SQL
+  create_view #{name.inspect}, #{materialized_option}sql_definition: <<-\SQL
     #{definition.indent(2)}
   SQL
       DEFINITION


### PR DESCRIPTION
Scenic dumps `db/schema.rb` with redundant space symbol before `sql_definition`  parameter:

Example 1:

```ruby
create_view "old_users",  sql_definition: <<-SQL
    SELECT users.id,
    users.name,
    users.age,
    users.created_at,
    users.updated_at
   FROM users
  WHERE (users.age > 100);
SQL
``` 

Example 2 with materialized view:

```ruby
create_view "young_users", materialized: true,  sql_definition: <<-SQL
    SELECT users.id,
    users.name,
    users.age,
    users.created_at,
    users.updated_at
   FROM users
  WHERE (users.age < 100);
SQL
```

This PR fixes it, so that there are no extra spaces before `sql_definition` and linters like rubocop don't complain here anymore.

After:

Example 1:

```ruby
create_view "old_users", sql_definition: <<-SQL
    SELECT users.id,
    users.name,
    users.age,
    users.created_at,
    users.updated_at
   FROM users
  WHERE (users.age > 100);
SQL
``` 

Example 2 with materialized view:

```ruby
create_view "young_users", materialized: true, sql_definition: <<-SQL
    SELECT users.id,
    users.name,
    users.age,
    users.created_at,
    users.updated_at
   FROM users
  WHERE (users.age < 100);
SQL
```